### PR TITLE
Upgrade webassets to deal with Django upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ test.db*
 
 # don't check in NCBI data
 ncbi/
+
+# compiled static files
+static/

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ clean-pyc:
 
 clean-js:
 	rm -rf src/edge/static/edge/lib/*
-	rm -vf src/edge/static/edge/edge{.css,.html,.js,.min.js,_jst.js}
+	rm -rvf src/edge/static/edge/assets/*
 
 
 # Testing

--- a/README.rst
+++ b/README.rst
@@ -34,27 +34,37 @@ Try it using Docker
 -------------------
 * Use ``docker-compose``:
 
-To start edge server:
+To start the edge server:
+
 ::
-    
+
     docker-compose up
-Then check it out in your browser: http://localhost:9000/edge/#/genomes
-To import an genome using:
+
+Then check it out in your browser: http://localhost:9000/edge/#/genomes .
+
+To import a genome, use:
+
 ::
+
     docker-compose run edge python src/manage.py import_gff 'Saccharomyces cerevisiae' example/sc_s288c.gff
-To run a shell inside the edge container
+
+To run a shell inside the Edge container:
+
 ::
+
     docker-compose run --rm edge bash
 
 * Alternatively, you can use the ``Makefile``:
 
 To start edge server:
+
 ::
 
     make start-ext
 
 
-To import an genome as an example:
+To import a genome as an example:
+
 ::
 
     make add-s288c-ext
@@ -66,11 +76,10 @@ trying to rebuild the image.
 The ``Makefile`` holds all the commands necessary for managing the server and
 database, both in usage and development. Run ``make`` without arguments to see a list of commmands.
 
-The Docker environment is defined in ``docker-compose.yml``. Ese the ``edge`` service for your
+The Docker environment is defined in ``docker-compose.yml``. Use the ``edge`` service for your
 commands.
 
-Of course, any of these ``make`` targets can be run directly from a shell inside a container from
-either service:
+Any of these ``make`` targets can be run directly from a shell inside a container:
 
 ::
 
@@ -125,10 +134,9 @@ Then, to set up the edge BLAST db, from the ``src`` subdirectory,
 Editing data
 ------------
 
-You can edit genome and fragment metadata, such as name, notes, circular
-attributes, from the Django admin. Create a Django admin superuser, (see the ``superuser`` make
-target), then set your browser to the ``/admin/`` endpoint of wherever you are running your dev
-server.
+You can edit genome and fragment metadata, such as name, notes, circular attributes, from the Django
+admin. Create a Django admin superuser, (see the ``superuser`` make target), then set your browser
+to the ``/admin/`` endpoint of wherever you are running your dev server.
 
 
 Deploying to production
@@ -138,7 +146,8 @@ Do *not* use the Dockerfile as-is for production, or the ``make run`` task. Djan
 command is not meant to run a production server. Instead, you'll need to spin up a production WSGI
 server and run the Django projct with that, with your own settings. In this situation, it's better
 to simply install the ``edge-genome`` python package on your deployed system and add it to your
-deployment Django server's ``installed_apps`` setting.
+deployment Django server's ``installed_apps`` setting. The package is designed so that, when built,
+it already contains all of the javascript assets compiled in their final state.
 
 
 Development, testing, and package release
@@ -146,6 +155,14 @@ Development, testing, and package release
 
 When developing locally, you can run tests in the controlled environment of the docker container
 from your local machine with ``make test-ext.``
+
+Note that edge uses webassets_ for compilation of static assets. These assets are not automatically
+compiled (because the integration of that with Django is flaky). Instead, compile assets after
+cahnging them with ``make build_assets``.
+
+Static dependencies are managed with Bower_. (Eventually to be replaced with npm_/webpack_).
+Dependencies are downloaded before the python package is built so python package consumers already
+have all required javascript.
 
 Edge is versioned semantically. Continuous integration is done automatically on all branches through
 Travis CI, and tagged commits to master are automatically released to PyPI. To release a new version,
@@ -158,3 +175,8 @@ push the resulting tagged commits to the GitHub remote repo:
     you@localhost:edge$ git push --tags origin master
 
 If you cannot push to master directly, do the same thing on a new branch and submit a pull request.
+
+.. _webassets: https://webassets.readthedocs.io/
+.. _Bower: https://bower.io/
+.. _npm: https://npmjs.org/
+.. _webpack: https://webpack.js.org/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       MYSQL_DATABASE: edge_dev
     volumes:
       - edge-db-data:/var/lib/mysql
-  
+
   rabbit:
     image: rabbitmq
 

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -10,7 +10,7 @@ flower==0.9.1
 bcbio-gff == 0.4
 
 # Web assets
-django_assets == 0.8
+django_assets == 0.12
 jsmin == 2.0.9
 
 numpy == 1.12.1

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,7 +1,4 @@
 db.sqlite3*
 test.db*
 .webassets-cache
-edge/static/edge/edge.css
-edge/static/edge/edge.js
-edge/static/edge/edge.min.js
-edge/static/edge/edge_jst.js
+edge/static/edge/assets/

--- a/src/edge/assets.py
+++ b/src/edge/assets.py
@@ -1,13 +1,17 @@
 from django_assets import Bundle, register
 
-js = Bundle('edge/src/js/*.js', filters='jsmin', output='edge/static/edge/edge.min.js')
+js = Bundle('edge/static/edge/src/js/*.js',
+            output='edge/static/edge/assets/edge.js')
 register('edge_js', js)
 
-js = Bundle('edge/src/js/*.js', output='edge/static/edge/edge.js')
-register('edge', js)
+jsmin = Bundle(js, filters='jsmin',
+               output='edge/static/edge/assets/edge.min.js')
+register('edge_jsmin', jsmin)
 
-css = Bundle('edge/src/css/app.css', output='edge/static/edge/edge.css')
+css = Bundle('edge/static/edge/src/css/app.css',
+             output='edge/static/edge/assets/edge.css')
 register('edge_css', css)
 
-jst = Bundle('edge/src/partials/*.html', filters='jst', output='edge/static/edge/edge_jst.js')
+jst = Bundle('edge/static/edge/src/partials/*.html', filters='jst',
+             output='edge/static/edge/assets/edge_jst.js')
 register('edge_jst', jst)

--- a/src/edge/templates/edge/edge.html
+++ b/src/edge/templates/edge/edge.html
@@ -18,10 +18,10 @@
     <!-- svjs -->
     <script src="{% static 'edge/lib/svjs/svjs.js' %}"></script>
     <link rel="stylesheet" href="{% static 'edge/lib/svjs/svjs.css' %}">
-    <!-- edge stuff -->
-    <script src="{% static 'edge/edge_jst.js' %}"></script>
-    <script src="{% static 'edge/edge.js' %}"></script>
-    <link rel="stylesheet" href="{% static 'edge/edge.css' %}">
+    <!-- compiled assets -->
+    <script src="{% static 'edge/assets/edge_jst.js' %}"></script>
+    <script src="{% static 'edge/assets/edge.js' %}"></script>
+    <link rel="stylesheet" href="{% static 'edge/assets/edge.css' %}">
 </head>
 <body>
 

--- a/src/edge/urls.py
+++ b/src/edge/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
     # we have to add a redirect from the static page to the /ui/ URL, for any
     # browser that have the redirect memorized.
 
-    url(r'^/?$', TemplateView.as_view(template_name='edge/edge.html'), name='edge-ui'),
+    url(r'^$', TemplateView.as_view(template_name='edge/edge.html'), name='edge-ui'),
     url(r'^ui/?$', TemplateView.as_view(template_name='edge/edge.html')),
 
     # APIs


### PR DESCRIPTION
- Fix directory paths
- Change compilation to move into separate assets folder
- Add global settings for webassets compilation
- Add global settings for static root assembly
- Add debug information and better error-outs to setup.py commands
- Remove needless / in root urlconf
- Add TEMPLATES settings to make server work in Django 1.11
- Make indentation consistently 4 spaces