### PR TITLE
Fix some issues with genomic PCR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,14 +125,15 @@ add-s288c:
 
 # Generically execute make targets from outside the Docker container
 
-MAKE_EXT = docker-compose run --rm --service-ports ${PROJECT_NAME} make -C ${EDGE_HOME}
+MAKE_EXT = docker-compose run --rm ${DOCKER_COMPOSE_ARGS} ${PROJECT_NAME} make -C ${EDGE_HOME}
 
-%-ext : image
+%-ext: DOCKER_COMPOSE_ARGS =--service-ports
+%-ext: image
 	${MAKE_EXT} $*
 
 # Run a command from outside the image without rebuilding the image; useful when you already have
-# a version of the image running
-%-ext_fast :
+# a container running and don't want to rebuild
+%-ext_fast:
 	${MAKE_EXT} $*
 
 # Build the image

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,4 @@
+====
 Edge
 ====
 
@@ -34,6 +35,9 @@ Try it using Docker
 -------------------
 * Use ``docker-compose``:
 
+The Docker environment is defined in ``docker-compose.yml``. Use the ``edge`` service for your
+commands.
+
 To start the edge server:
 
 ::
@@ -56,11 +60,32 @@ To run a shell inside the Edge container:
 
 * Alternatively, you can use the ``Makefile``:
 
-To start edge server:
+The ``Makefile`` holds all the commands necessary for managing the server and database, both in
+usage and development. Run ``make`` without arguments to see a list of commmands.
+
+Any of these ``make`` targets can be run directly from a shell inside a container:
+
+::
+
+    you@localhost:edge$ docker-compose run --rm edge bash
+    # Now you're inside the Docker container
+    root@docker-image:/usr/src/edge# make test
+
+Furthermore, any target can have ``-ext`` added to it. Commands that end in ``-ext`` are meant to be
+run *externally* to the image, *i.e.*, from the host system.
+
+For example, to start the edge server:
 
 ::
 
     make start-ext
+
+
+To run a shell:
+
+::
+
+    make bash-ext
 
 
 To import a genome as an example:
@@ -70,22 +95,9 @@ To import a genome as an example:
     make add-s288c-ext
 
 
-Or, if your app is already running, ``make add-s288c-ext_fast``, which will run the job without
+If the edge app is already running in a container, or you don't want to rebuild the image yet, you
+can change ``-ext`` to ``-ext_fast``, which will run the make target in a new container without
 trying to rebuild the image.
-
-The ``Makefile`` holds all the commands necessary for managing the server and
-database, both in usage and development. Run ``make`` without arguments to see a list of commmands.
-
-The Docker environment is defined in ``docker-compose.yml``. Use the ``edge`` service for your
-commands.
-
-Any of these ``make`` targets can be run directly from a shell inside a container:
-
-::
-
-    you@localhost:edge$ docker-compose run --rm edge bash
-    # Now you're inside the Docker container
-    root@docker-image:/usr/src/edge# make test
 
 
 Try it without Docker
@@ -153,21 +165,33 @@ it already contains all of the javascript assets compiled in their final state.
 Development, testing, and package release
 -----------------------------------------
 
+Running tests
+~~~~~~~~~~~~~
+
 When developing locally, you can run tests in the controlled environment of the docker container
-from your local machine with ``make test-ext.``
+from your local machine with ``make test-all-ext``. Make sure you've run the migrations at least once
+before doing this. If your server is already running, and you want to run tests from the host
+machine in a separate container, use ``make test-all-ext_fast``. Or just keep a container up and run
+the tests from inside it.
+
+Static files
+~~~~~~~~~~~~
 
 Note that edge uses webassets_ for compilation of static assets. These assets are not automatically
 compiled (because the integration of that with Django is flaky). Instead, compile assets after
-cahnging them with ``make build_assets``.
+cahnging them with ``make build_assets``. To constantly recompile them, see ``make watch``.
 
 Static dependencies are managed with Bower_. (Eventually to be replaced with npm_/webpack_).
-Dependencies are downloaded before the python package is built so python package consumers already
-have all required javascript.
+Dependencies are downloaded before the python package is built so Python package consumers already
+have all required JavaScript.
 
-Edge is versioned semantically. Continuous integration is done automatically on all branches through
-Travis CI, and tagged commits to master are automatically released to PyPI. To release a new version,
-bump the version number with the appropriate severity of the changes (major, minor, or patch), and
-push the resulting tagged commits to the GitHub remote repo:
+Versioning
+~~~~~~~~~~
+
+Edge is versioned semantically. Continuous integration builds are done automatically on all branches
+through Travis CI, and tagged commits to master are automatically released to PyPI. To release a new
+version, bump the version number with the appropriate severity of the changes (major, minor, or
+patch), and push the resulting tagged commits to the GitHub remote repo:
 
 ::
 

--- a/run-tests
+++ b/run-tests
@@ -1,2 +1,0 @@
-docker-compose run --rm edge make test-ci
-docker-compose run --rm edge make flake8

--- a/run-tests
+++ b/run-tests
@@ -1,0 +1,2 @@
+docker-compose run --rm edge make test-ci
+docker-compose run --rm edge make flake8

--- a/src/edge/blast.py
+++ b/src/edge/blast.py
@@ -93,7 +93,6 @@ def blast(dbname, blast_program, query, evalue_threshold=0.001):
 
     cl = str(blast_cl)
     cl = "%s/%s" % (settings.NCBI_BIN_DIR, cl)
-    # print cl
     r = subprocess.call(cl.split(" "))
     os.unlink(infile)
 
@@ -137,11 +136,10 @@ def blast(dbname, blast_program, query, evalue_threshold=0.001):
     return results
 
 
-def blast_genome(genome, blast_program, query, evalue_threshold=0.001):
+def blast_genome(genome, blast_program, query, evalue_threshold=0.01):
     dbname = genome.blastdb
     if not dbname:
         return []
-    results = blast(dbname, blast_program, query,
-                    evalue_threshold=evalue_threshold)
+    results = blast(dbname, blast_program, query, evalue_threshold=evalue_threshold)
     genome_fragment_ids = [f.id for f in genome.fragments.all()]
     return [r for r in results if r.fragment_id in genome_fragment_ids]

--- a/src/edge/tests/test_blast.py
+++ b/src/edge/tests/test_blast.py
@@ -147,8 +147,8 @@ class GenomeBlastTest(TestCase):
         res = blast_genome(g1, 'blastn', query)
 
         for r in res:
-            self.assertEquals(r.subject_start > 0 and r.subject_start < len(s1), True)
-            self.assertEquals(r.subject_end > 0 and r.subject_end < len(s1), True)
+            self.assertEquals(r.subject_start > 0 and r.subject_start <= len(s1), True)
+            self.assertEquals(r.subject_end > 0 and r.subject_end <= len(s1), True)
 
 
 class GenomeBlastAPITest(TestCase):

--- a/src/edge/tests/test_pcr.py
+++ b/src/edge/tests/test_pcr.py
@@ -37,8 +37,9 @@ class GenomePcrTest(TestCase):
         g = self.build_genome(False, template)
         r = pcr_from_genome(g, p1, p2)
         self.assertEquals(r[0], ''.join([p1, middle, str(Seq(p2).reverse_complement())]))
-        self.assertEquals(len(r[1]), 1)  # one binding site for each primer
-        self.assertEquals(len(r[2]), 1)  # one binding site for each primer
+        # 1 binding site + 5 partial primer binding sites (-15 to -20 bps of primers)
+        self.assertEquals(len(r[1]), 6)  # one binding site for each primer
+        self.assertEquals(len(r[2]), 6)  # one binding site for each primer
         self.assertEquals(r[3]['fragment_name'], g.fragments.all()[0].name)
         self.assertEquals(r[3]['fragment_id'], g.fragments.all()[0].id)
         self.assertEquals(
@@ -114,8 +115,10 @@ class GenomePcrTest(TestCase):
         g = self.build_genome(False, template)
         r = pcr_from_genome(g, p1, p2)
         self.assertEquals(r[0], ''.join([p1, middle, str(Seq(p2).reverse_complement())]))
-        self.assertEquals(len(r[1]), 2)  # two binding sites for each primer
-        self.assertEquals(len(r[2]), 1)  # one binding site for this primer
+        # 2 binding sites + 2*5 partial primer binding sites (-15 to -20 bps of primers)
+        self.assertEquals(len(r[1]), 12)  # two binding sites for each primer
+        # 1 binding site + 5 partial primer binding sites (-15 to -20 bps of primers)
+        self.assertEquals(len(r[2]), 6)  # one binding site for this primer
         self.assertEquals(r[3]['fragment_name'], g.fragments.all()[0].name)
         self.assertEquals(r[3]['fragment_id'], g.fragments.all()[0].id)
         self.assertEquals(
@@ -135,8 +138,9 @@ class GenomePcrTest(TestCase):
         g = self.build_genome(False, template)
         r = pcr_from_genome(g, p1, p2)
         self.assertEquals(r[0], None)
-        self.assertEquals(len(r[1]), 2)  # two binding sites for each primer
-        self.assertEquals(len(r[2]), 2)  # two binding sites for each primer
+        # 2 binding sites + 2*5 partial primer binding sites (-15 to -20 bps of primers)
+        self.assertEquals(len(r[1]), 12)  # two binding sites for each primer
+        self.assertEquals(len(r[2]), 12)  # two binding sites for each primer
 
     def test_pcr_does_not_produce_product_when_primer_binding_site_is_too_small(self):
         p1_bs = "catagcgcacaggacgcggag"
@@ -151,8 +155,9 @@ class GenomePcrTest(TestCase):
         g = self.build_genome(False, template)
         r = pcr_from_genome(g, p1, p2)
         self.assertEquals(r[0], None)
-        self.assertEquals(len(r[1]), 1)
-        self.assertEquals(len(r[2]), 0)
+        # 1 binding site + 5 partial primer binding sites (-15 to -20 bps of primers)
+        self.assertEquals(len(r[1]), 6)
+        self.assertEquals(len(r[2]), 6)
 
     def test_pcr_does_not_produce_product_when_primer_binding_site_has_too_many_mutations(self):
         def mutate(s, n):
@@ -180,14 +185,16 @@ class GenomePcrTest(TestCase):
         g = self.build_genome(False, template)
         r = pcr_from_genome(g, p1, p2)
         self.assertEquals(r[0], None)
-        self.assertEquals(len(r[1]), 1)
-        self.assertEquals(len(r[2]), 1)
+        # 1 binding site + 5 partial primer binding sites (-15 to -20 bps of primers)
+        self.assertEquals(len(r[1]), 6)
+        self.assertEquals(len(r[2]), 6)
 
         g = self.build_genome(False, template)
         r = pcr_from_genome(g, p1_good, p2)
         self.assertEquals(r[0], ''.join([p1_good, middle, str(Seq(p2).reverse_complement())]))
-        self.assertEquals(len(r[1]), 1)
-        self.assertEquals(len(r[2]), 1)
+        # 1 binding site + 5 partial primer binding sites (-15 to -20 bps of primers)
+        self.assertEquals(len(r[1]), 6)
+        self.assertEquals(len(r[2]), 6)
 
     def test_pcr_does_not_produce_product_when_primer_binds_to_different_fragments(self):
         p1_bs = "catagcgcacaggacgcggag"
@@ -203,8 +210,9 @@ class GenomePcrTest(TestCase):
         g = self.build_genome(False, template1, template2)
         r = pcr_from_genome(g, p1, p2)
         self.assertEquals(r[0], None)
-        self.assertEquals(len(r[1]), 1)
-        self.assertEquals(len(r[2]), 1)
+        # 1 binding site + 5 partial primer binding sites (-15 to -20 bps of primers)
+        self.assertEquals(len(r[1]), 6)
+        self.assertEquals(len(r[2]), 6)
 
     def test_pcr_does_produce_product_when_duplicate_regions_on_different_genome(self):
         p1_bs = "catagcgcacaggacgcggag"
@@ -221,13 +229,15 @@ class GenomePcrTest(TestCase):
 
         r = pcr_from_genome(g1, p1, p2)
         self.assertEquals(r[0], None)
-        self.assertEquals(len(r[1]), 2)  # two binding sites for each primer
-        self.assertEquals(len(r[2]), 2)  # two binding sites for each primer
+        # 2 binding sites + 2*5 partial primer binding sites (-15 to -20 bps of primers)
+        self.assertEquals(len(r[1]), 12)  # two binding sites for each primer
+        self.assertEquals(len(r[2]), 12)  # two binding sites for each primer
 
         r = pcr_from_genome(g2, p1, p2)
         self.assertEquals(r[0], ''.join([p1, middle, str(Seq(p2).reverse_complement())]))
-        self.assertEquals(len(r[1]), 1)
-        self.assertEquals(len(r[2]), 1)
+        # 1 binding site + 5 partial primer binding sites (-15 to -20 bps of primers)
+        self.assertEquals(len(r[1]), 6)
+        self.assertEquals(len(r[2]), 6)
 
     def test_pcr_api(self):
         upstream = "gagattgtccgcgtttt"
@@ -248,12 +258,16 @@ class GenomePcrTest(TestCase):
 
         self.assertEquals(len(d), 4)
         self.assertEquals(d[0], ''.join([p1, middle, str(Seq(p2).reverse_complement())]))
-        self.assertEquals(len(d[1]), 1)
+        # 1 binding site + 5 partial primer binding sites (-15 to -20 bps of primers)
+        self.assertEquals(len(d[1]), 6)
+        # first set of binding location = max primer binding location
         self.assertEquals(d[1][0]['subject_start'], len(upstream) + 1)
         self.assertEquals(d[1][0]['subject_end'], len(upstream) + len(p1_bs))
         self.assertEquals(d[1][0]['query_start'], len(p1) - len(p1_bs) + 1)
         self.assertEquals(d[1][0]['query_end'], len(p1))
-        self.assertEquals(len(d[2]), 1)
+        # 1 binding site + 5 partial primer binding sites (-15 to -20 bps of primers)
+        self.assertEquals(len(d[2]), 6)
+        # first set of binding location = max primer binding location
         self.assertEquals(d[2][0]['subject_start'], len(template) - len(downstream))
         self.assertEquals(d[2][0]['subject_end'], len(template) - len(downstream) - len(p2_bs) + 1)
         self.assertEquals(d[2][0]['query_start'], len(p2) - len(p2_bs) + 1)


### PR DESCRIPTION
Decrease default evalue threshold for genome PCR, and check multiple primer binding lengths to ensure we find where the primer lands on the genome