### PR TITLE
Add refresh option for build_fragment_fasta

### DIFF
--- a/src/edge/blastdb.py
+++ b/src/edge/blastdb.py
@@ -31,7 +31,7 @@ def build_fragment_fasta(fragment, refresh=False):
     fn = fragment_fasta_fn(fragment)
     make_required_dirs(fn)
 
-    if not os.path.isfile(fn) or refresh is True:  # have not built this fasta
+    if not os.path.isfile(fn) or refresh:  # have not built this fasta or need refresh
         print 'building %s' % fn
         # this may take awhile, so do this first, so user interrupt does
         # not create an empty file

--- a/src/edge/blastdb.py
+++ b/src/edge/blastdb.py
@@ -27,11 +27,11 @@ def fragment_fasta_fn(fragment):
                                                            fragment.id)
 
 
-def build_fragment_fasta(fragment):
+def build_fragment_fasta(fragment, refresh=False):
     fn = fragment_fasta_fn(fragment)
     make_required_dirs(fn)
 
-    if not os.path.isfile(fn):  # have not built this fasta
+    if not os.path.isfile(fn) or refresh is True:  # have not built this fasta
         print 'building %s' % fn
         # this may take awhile, so do this first, so user interrupt does
         # not create an empty file
@@ -58,7 +58,7 @@ def build_db(fragments, dbname, refresh=True):
 
     fns = []
     for fragment in fragments:
-        fn = build_fragment_fasta(fragment)
+        fn = build_fragment_fasta(fragment, refresh)
         fns.append(fn)
 
     print 'concat fasta files for %s' % dbname


### PR DESCRIPTION
If refresh is True, force rebuilding the blastdb, this refresh
parameter is passed down from build_db in the build_db code. So when
build_db is called with refresh=True, fragment blastdb will be rebuilt,
which should be the correct behavior.