### PR TITLE
Update Dockerfile to enable npm setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,12 @@ RUN git config --global user.name "$GIT_USER_NAME" \
 
 
 ARG DEBIAN_FRONTEND=noninteractive
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update
 RUN apt-get install --assume-yes --verbose-versions \
   apt-utils \
   mysql-client \
   nodejs \
-  nodejs-legacy \
-  npm \
   ncbi-blast+ \
   primer3
 


### PR DESCRIPTION
No longer able to apt-get install npm so need this change in order for
this Dockerfile to continue working.