### PR TITLE
Add queryset evaluation to actually lock root genome

### DIFF
--- a/src/edge/views.py
+++ b/src/edge/views.py
@@ -499,6 +499,7 @@ class GenomeOperationViewBase(ViewBase):
             if child is None:
                 child = op_class.perform(genome, **args)
                 if child:
+                    print(f'Generated child genome {child.id} from parent genome {genome_id}')
                     schedule_building_blast_db(child.id)
                     return GenomeView.to_dict(child), 201
             else:  # found existing child, update genome name and set to active


### PR DESCRIPTION
https://docs.djangoproject.com/en/2.2/ref/models/querysets/#select-for-u
pdate doc tells that only `When the queryset is evaluated (for entry in
entries in this case),` the lock will happen. I tested this on
edge-staging and works as expected. The previous version without
queryset evaluation did not work.