### PR TITLE
add qualifiers from JSON API to annotation

### DIFF
--- a/scripts/flake8
+++ b/scripts/flake8
@@ -1,0 +1,1 @@
+docker-compose -f docker-compose.yml run --rm edge make flake8

--- a/src/edge/tests/test_views.py
+++ b/src/edge/tests/test_views.py
@@ -363,6 +363,27 @@ class FragmentTest(TestCase):
             "feature_base_last": 8,
         }])
 
+    def test_add_annotation_with_qualifiers(self):
+        data = dict(base_first=2, base_last=9, name='proC', type='promoter', strand=1,
+                    qualifiers=dict(gene="PROC"))
+        res = self.client.post(self.uri + 'annotations/', data=json.dumps(data),
+                               content_type='application/json')
+        self.assertEquals(res.status_code, 201)
+        self.assertEquals(json.loads(res.content), {})
+        res = self.client.get(self.uri + 'annotations/')
+        self.assertEquals(res.status_code, 200)
+        self.assertEquals(json.loads(res.content), [{
+            "base_first": 2,
+            "base_last": 9,
+            "name": 'proC',
+            "type": 'promoter',
+            "strand": 1,
+            "qualifiers": {"gene": "PROC"},
+            "feature_full_length": 8,
+            "feature_base_first": 1,
+            "feature_base_last": 8,
+        }])
+
     def test_add_annotation_on_reverse_strand(self):
         data = dict(base_first=3, base_last=10, name='proC', type='promoter', strand=-1)
         res = self.client.post(self.uri + 'annotations/', data=json.dumps(data),

--- a/src/edge/views.py
+++ b/src/edge/views.py
@@ -210,6 +210,8 @@ class FragmentAnnotationsView(ViewBase):
         annotation_parser.add_argument('name', field_type=str, required=True, location='json')
         annotation_parser.add_argument('type', field_type=str, required=True, location='json')
         annotation_parser.add_argument('strand', field_type=int, required=True, location='json')
+        annotation_parser.add_argument('qualifiers', field_type=dict, required=False,
+                                       default=None, location='json')
 
         args = annotation_parser.parse_args(request)
         fragment = get_fragment_or_404(fragment_id)
@@ -218,7 +220,8 @@ class FragmentAnnotationsView(ViewBase):
                           last_base1=args['base_last'],
                           name=args['name'],
                           type=args['type'],
-                          strand=args['strand'])
+                          strand=args['strand'],
+                          qualifiers=args['qualifiers'])
         return {}, 201
 
 


### PR DESCRIPTION
Each annotation has a "qualifiers" field which stores information from GFF. POST API did not allow caller to provide a qualifier field. This MR fixes it.