### PR TITLE
Allow annotation of donor DNA when doing a HR

### DIFF
--- a/src/edge/recombine.py
+++ b/src/edge/recombine.py
@@ -146,7 +146,7 @@ def get_cassette_inherited_annotations(genome, cassette, fragment_id, region_sta
     return inherited_annotations
 
 
-def get_cassette_new_annotations(cassette):
+def get_cassette_new_annotations(cassette, new_annotations):
     # detect ORF on cassette
 
     annotations = []
@@ -154,15 +154,27 @@ def get_cassette_new_annotations(cassette):
         annotations.append(dict(base_first=orf['start'], base_last=orf['end'],
                                 feature_name=orf['name'],
                                 feature_type='ORF',
-                                feature_strand=orf['strand']))
+                                feature_strand=orf['strand'],
+                                feature_qualifiers=None))
+
+    if new_annotations:
+        for annotation in new_annotations:
+            annotations.append(
+                dict(base_first=annotation['start'], base_last=annotation['end'],
+                     feature_name=annotation['name'],
+                     feature_type=annotation['type'],
+                     feature_strand=annotation['strand'],
+                     feature_qualifiers=annotation['qualifiers'] \
+                         if 'qualifiers' in annotation else None))
 
     return annotations
 
 
-def get_cassette_annotations(genome, cassette, fragment_id, region_start, region_end):
+def get_cassette_annotations(genome, cassette, fragment_id, region_start, region_end,
+                             new_annotations):
     return get_cassette_inherited_annotations(
         genome, cassette, fragment_id, region_start, region_end) + get_cassette_new_annotations(
-        cassette)
+        cassette, new_annotations)
 
 
 class RecombinationRegion(object):
@@ -196,7 +208,7 @@ class RecombinationRegion(object):
 
     def update_annotations(self, genome):
         self.cassette_annotations = \
-            get_cassette_annotations(genome, self.cassette, self.fragment_id, self.start, self.end)
+            get_cassette_annotations(genome, self.cassette, self.fragment_id, self.start, self.end, None)
 
 
 def compute_swap_region_from_results(front_arm_sequence, front_arm_blastres,
@@ -631,12 +643,16 @@ def recombine_sequence(genome, cassette, homology_arm_length,
                 operation=op)
 
 
-def annotate_integration(genome, new_genome, regions_before, regions_after, cassette_name, op):
+def annotate_integration(genome, new_genome, regions_before, regions_after,
+                         cassette_name, op, cassette, new_annotations):
 
     before_and_after_with_annotations = []
     for before, after in zip(regions_before, regions_after):
+        if before['cassette'].lower() != cassette.lower():
+           # opps, annotations no longer match, ignore them for now
+           new_annotations = []
         annotations = get_cassette_annotations(genome, before['cassette'], before['fragment_id'],
-                                               before['start'], before['end'])
+                                               before['start'], before['end'], new_annotations)
         before_and_after_with_annotations.append((before, after, annotations))
 
     # lock root genome to prevent other genomes of touching same fragment or chunk
@@ -663,14 +679,18 @@ def annotate_integration(genome, new_genome, regions_before, regions_after, cass
                            after['start'] + annotation['base_last'] - 1,
                            annotation['feature_name'],
                            annotation['feature_type'],
-                           annotation['feature_strand'])
+                           annotation['feature_strand'],
+                           qualifiers=annotation['feature_qualifiers'] \
+                               if 'feature_qualifiers' in annotation else None)
 
 
 def recombine(genome, cassette, homology_arm_length,
-              genome_name=None, cassette_name=None, notes=None):
+              genome_name=None, cassette_name=None,
+              notes=None, annotations=None):
 
     x = recombine_sequence(genome, cassette, homology_arm_length,
-                           genome_name=genome_name, cassette_name=cassette_name, notes=notes)
+                           genome_name=genome_name,
+                           cassette_name=cassette_name, notes=notes)
 
     if x is None:
         return x
@@ -680,7 +700,7 @@ def recombine(genome, cassette, homology_arm_length,
     annotate_integration_task.apply_async(
         (genome.id, x['new_genome'].id,
          x['regions']['before'], x['regions']['after'],
-         x['cassette_name'], x['operation'].id), countdown=10)
+         x['cassette_name'], x['operation'].id, cassette, annotations), countdown=10)
 
     return x['new_genome']
 
@@ -690,7 +710,7 @@ class RecombineOp(object):
     @staticmethod
     def check(genome, cassette, homology_arm_length,
               genome_name=None, cassette_name=None, notes=None,
-              design_primers=False, primer3_opts=None):
+              design_primers=False, primer3_opts=None, annotations=None):
         return find_swap_region_with_annotations(genome, cassette, homology_arm_length,
                                                  design_primers=design_primers,
                                                  primer3_opts=primer3_opts)
@@ -706,6 +726,7 @@ class RecombineOp(object):
 
     @staticmethod
     def perform(genome, cassette, homology_arm_length, genome_name, cassette_name, notes,
-                design_primers=False, primer3_opts=None):
+                design_primers=False, primer3_opts=None, annotations=None):
         return recombine(genome, cassette, homology_arm_length,
-                         genome_name=genome_name, cassette_name=cassette_name, notes=notes)
+                         genome_name=genome_name, cassette_name=cassette_name,
+                         notes=notes, annotations=annotations)

--- a/src/edge/recombine.py
+++ b/src/edge/recombine.py
@@ -160,12 +160,12 @@ def get_cassette_new_annotations(cassette, new_annotations):
     if new_annotations:
         for annotation in new_annotations:
             annotations.append(
-                dict(base_first=annotation['start'], base_last=annotation['end'],
+                dict(base_first=annotation['base_first'], base_last=annotation['base_last'],
                      feature_name=annotation['name'],
                      feature_type=annotation['type'],
                      feature_strand=annotation['strand'],
-                     feature_qualifiers=annotation['qualifiers'] \
-                         if 'qualifiers' in annotation else None))
+                     feature_qualifiers=annotation['qualifiers']
+                     if 'qualifiers' in annotation else None))
 
     return annotations
 
@@ -208,7 +208,8 @@ class RecombinationRegion(object):
 
     def update_annotations(self, genome):
         self.cassette_annotations = \
-            get_cassette_annotations(genome, self.cassette, self.fragment_id, self.start, self.end, None)
+            get_cassette_annotations(genome, self.cassette, self.fragment_id,
+                                     self.start, self.end, None)
 
 
 def compute_swap_region_from_results(front_arm_sequence, front_arm_blastres,
@@ -649,8 +650,8 @@ def annotate_integration(genome, new_genome, regions_before, regions_after,
     before_and_after_with_annotations = []
     for before, after in zip(regions_before, regions_after):
         if before['cassette'].lower() != cassette.lower():
-           # opps, annotations no longer match, ignore them for now
-           new_annotations = []
+            # opps, annotations no longer match, ignore them for now
+            new_annotations = []
         annotations = get_cassette_annotations(genome, before['cassette'], before['fragment_id'],
                                                before['start'], before['end'], new_annotations)
         before_and_after_with_annotations.append((before, after, annotations))
@@ -680,8 +681,8 @@ def annotate_integration(genome, new_genome, regions_before, regions_after,
                            annotation['feature_name'],
                            annotation['feature_type'],
                            annotation['feature_strand'],
-                           qualifiers=annotation['feature_qualifiers'] \
-                               if 'feature_qualifiers' in annotation else None)
+                           qualifiers=annotation['feature_qualifiers']
+                           if 'feature_qualifiers' in annotation else None)
 
 
 def recombine(genome, cassette, homology_arm_length,
@@ -718,7 +719,7 @@ class RecombineOp(object):
     @staticmethod
     def get_operation(cassette, homology_arm_length,
                       genome_name=None, cassette_name=None, notes=None,
-                      design_primers=False, primer3_opts=None):
+                      design_primers=False, primer3_opts=None, annotations=None):
         cassette = remove_overhangs(cassette)
         params = dict(cassette=cassette, homology_arm_length=homology_arm_length)
         op = Operation(type=Operation.RECOMBINATION[0], params=json.dumps(params))

--- a/src/edge/recombine.py
+++ b/src/edge/recombine.py
@@ -681,8 +681,7 @@ def annotate_integration(genome, new_genome, regions_before, regions_after,
                            annotation['feature_name'],
                            annotation['feature_type'],
                            annotation['feature_strand'],
-                           qualifiers=annotation['feature_qualifiers']
-                           if 'feature_qualifiers' in annotation else None)
+                           qualifiers=annotation.get('feature_qualifiers'))
 
 
 def recombine(genome, cassette, homology_arm_length,

--- a/src/edge/recombine.py
+++ b/src/edge/recombine.py
@@ -164,8 +164,7 @@ def get_cassette_new_annotations(cassette, new_annotations):
                      feature_name=annotation['name'],
                      feature_type=annotation['type'],
                      feature_strand=annotation['strand'],
-                     feature_qualifiers=annotation['qualifiers']
-                     if 'qualifiers' in annotation else None))
+                     feature_qualifiers=annotation.get('qualifiers'))
 
     return annotations
 

--- a/src/edge/tasks.py
+++ b/src/edge/tasks.py
@@ -14,16 +14,18 @@ def build_genome_blastdb(genome_id):
 @transaction.atomic()
 def annotate_integration_on_genome(genome, new_genome,
                                    regions_before, regions_after,
-                                   cassette_name, op):
-    annotate_integration(genome, new_genome, regions_before, regions_after, cassette_name, op)
+                                   cassette_name, op, cassette, annotations):
+    annotate_integration(genome, new_genome, regions_before, regions_after,
+                         cassette_name, op, cassette, annotations)
 
 
 @shared_task
 def annotate_integration_task(genome_id, new_genome_id,
                               regions_before, regions_after,
-                              cassette_name, op_id):
+                              cassette_name, op_id, cassette, annotations):
     genome = Genome.objects.get(pk=genome_id)
     new_genome = Genome.objects.get(pk=new_genome_id)
     op = Operation.objects.get(pk=op_id)
     annotate_integration_on_genome(genome, new_genome,
-                                   regions_before, regions_after, cassette_name, op)
+                                   regions_before, regions_after,
+                                   cassette_name, op, cassette, annotations)

--- a/src/edge/tests/test_recombine_annotations.py
+++ b/src/edge/tests/test_recombine_annotations.py
@@ -1,4 +1,5 @@
 import os
+import json
 
 from Bio.Seq import Seq
 from django.test import TestCase
@@ -287,19 +288,187 @@ class GenomeRecombinationAnnotationsTest(TestCase):
         self.assertEquals(a.base_last, len(self.upstream) + len(self.front_bs) + len(self.middle))
 
     def test_preserves_annotations_on_homology_arm_fwd_that_have_not_changed(self):
-        self.assertEquals(True, False)
+        cassette = ''.join([self.front_bs, self.back_bs])
+
+        # add annotaiton on upstream arm
+        self.fragment.annotate(len(self.upstream) + 2,
+                               len(self.upstream) + len(self.front_bs),
+                               "Up arm", "feature", 1)
+
+        c = recombine(self.genome, cassette, self.arm_len)
+        f = c.fragments.all()[0].indexed_fragment()
+
+        annotations = f.annotations()
+        self.assertEquals(len(annotations), 2)
+
+        a = annotations[0]
+        self.assertEquals(a.feature.type, 'operation')
+
+        a = annotations[1]
+        self.assertEquals(a.feature.name, 'Up arm')
+        self.assertEquals(a.feature.type, 'feature')
+        self.assertEquals(a.feature.strand, 1)
+        self.assertEquals(a.base_first, len(self.upstream) + 2)
+        self.assertEquals(a.base_last, len(self.upstream) + len(self.front_bs))
 
     def test_preserves_annotations_on_homology_arm_rev_that_have_not_changed(self):
-        self.assertEquals(True, False)
+        cassette = ''.join([self.front_bs, self.back_bs])
 
-    def test_annotates_orf_in_reverse_cassette(self):
-        self.assertEquals(True, False)
+        # add annotaiton on reverse strand of downstream arm
+        self.fragment.annotate(
+            len(self.upstream) + len(self.front_bs) + len(self.middle) + 1,
+            len(self.upstream) + len(self.front_bs) + len(self.middle) + len(self.back_bs),
+            "Down arm", "feature", -1)
 
-    def test_inherit_annotations_on_reverse_strand(self):
-        self.assertEquals(True, False)
+        c = recombine(self.genome, cassette, self.arm_len)
+        f = c.fragments.all()[0].indexed_fragment()
+
+        annotations = f.annotations()
+        self.assertEquals(len(annotations), 2)
+
+        a = annotations[0]
+        self.assertEquals(a.feature.type, 'operation')
+
+        a = annotations[1]
+        self.assertEquals(a.feature.name, 'Down arm')
+        self.assertEquals(a.feature.type, 'feature')
+        self.assertEquals(a.feature.strand, -1)
+        self.assertEquals(a.base_first, len(self.upstream) + len(self.front_bs) + 1)
+        self.assertEquals(a.base_last, len(self.upstream) + len(self.front_bs) + len(self.back_bs))
 
     def test_adds_annotations_on_fwd_strand(self):
-        self.assertEquals(True, False)
+        donor = "a" * 100 + "g" * 100 + "c" * 50 + "t" * 50 + "g" * 100 + "c" * 100
+        cassette = ''.join([self.front_bs, donor, self.back_bs])
+        flen = len(self.front_bs)
 
-    def test_adds_annotations_on_rev_strand(self):
-        self.assertEquals(True, False)
+        annotations = [
+          dict(base_first=flen + 1,   base_last=flen + 100, name="pFavorite", type="promoter",
+               strand=1, qualifiers=None),
+          dict(base_first=flen + 101, base_last=flen + 200, name="Favorite", type="gene",
+               strand=1, qualifiers=dict(locus="Favorite", product="Favoritep")),
+          dict(base_first=flen + 201, base_last=flen + 250, name="tFavorite", type="terminator",
+               strand=1, qualifiers=None),
+          dict(base_first=flen + 251, base_last=flen + 300, name="tBest", type="terminator",
+               strand=-1, qualifiers=None),
+          dict(base_first=flen + 301, base_last=flen + 400, name="Best", type="gene",
+               strand=-1, qualifiers=dict(locus="Best", product="Bestp")),
+          dict(base_first=flen + 401, base_last=flen + 500, name="pBest", type="promoter",
+               strand=-1, qualifiers=None)
+        ]
+
+        c = recombine(self.genome, cassette, self.arm_len, annotations=annotations)
+        f = c.fragments.all()[0].indexed_fragment()
+        fragment_sequence = f.sequence
+
+        ans = f.annotations()
+        self.assertEquals(len(ans), 7)
+
+        ans = sorted(ans, key=lambda a: (a.base_first, -a.base_last))
+
+        self.assertEquals(ans[0].feature.type, 'operation')
+
+        self.assertEquals(ans[1].feature.type, 'promoter')
+        self.assertEquals(ans[1].feature.name, 'pFavorite')
+        self.assertEquals(ans[1].feature.strand, 1)
+        self.assertEquals(ans[1].base_first, len(self.upstream) + len(self.front_bs) + 1)
+        self.assertEquals(ans[1].base_last, len(self.upstream) + len(self.front_bs) + 100)
+        self.assertEquals(fragment_sequence[ans[1].base_first - 1:ans[1].base_last], "a" * 100)
+
+        self.assertEquals(ans[2].feature.type, 'gene')
+        self.assertEquals(ans[2].feature.name, 'Favorite')
+        self.assertEquals(ans[2].feature.strand, 1)
+        self.assertEquals(ans[2].base_first, len(self.upstream) + len(self.front_bs) + 100 + 1)
+        self.assertEquals(ans[2].base_last, len(self.upstream) + len(self.front_bs) + 100 + 100)
+        self.assertEquals(fragment_sequence[ans[2].base_first - 1:ans[2].base_last], "g" * 100)
+
+        self.assertEquals(ans[3].feature.type, 'terminator')
+        self.assertEquals(ans[3].feature.name, 'tFavorite')
+        self.assertEquals(ans[3].feature.strand, 1)
+        self.assertEquals(ans[3].base_first, len(self.upstream) + len(self.front_bs) + 200 + 1)
+        self.assertEquals(ans[3].base_last, len(self.upstream) + len(self.front_bs) + 200 + 50)
+        self.assertEquals(fragment_sequence[ans[3].base_first - 1:ans[3].base_last], "c" * 50)
+
+        self.assertEquals(ans[4].feature.type, 'terminator')
+        self.assertEquals(ans[4].feature.name, 'tBest')
+        self.assertEquals(ans[4].feature.strand, -1)
+        self.assertEquals(ans[4].base_first, len(self.upstream) + len(self.front_bs) + 250 + 1)
+        self.assertEquals(ans[4].base_last, len(self.upstream) + len(self.front_bs) + 250 + 50)
+        self.assertEquals(fragment_sequence[ans[4].base_first - 1:ans[4].base_last], "t" * 50)
+
+        self.assertEquals(ans[5].feature.type, 'gene')
+        self.assertEquals(ans[5].feature.name, 'Best')
+        self.assertEquals(ans[5].feature.strand, -1)
+        self.assertEquals(ans[5].base_first, len(self.upstream) + len(self.front_bs) + 300 + 1)
+        self.assertEquals(ans[5].base_last, len(self.upstream) + len(self.front_bs) + 300 + 100)
+        self.assertEquals(fragment_sequence[ans[5].base_first - 1:ans[5].base_last], "g" * 100)
+
+        self.assertEquals(ans[6].feature.type, 'promoter')
+        self.assertEquals(ans[6].feature.name, 'pBest')
+        self.assertEquals(ans[6].feature.strand, -1)
+        self.assertEquals(ans[6].base_first, len(self.upstream) + len(self.front_bs) + 400 + 1)
+        self.assertEquals(ans[6].base_last, len(self.upstream) + len(self.front_bs) + 400 + 100)
+        self.assertEquals(fragment_sequence[ans[6].base_first - 1:ans[6].base_last], "c" * 100)
+
+    def test_passes_annotations_through_api(self):
+        donor = "a" * 100 + "g" * 100 + "c" * 50 + "t" * 50 + "g" * 100 + "c" * 100
+        cassette = ''.join([self.front_bs, donor, self.back_bs])
+        flen = len(self.front_bs)
+
+        annotations = [
+          dict(base_first=flen + 1,   base_last=flen + 100, name="pFavorite", type="promoter",
+               strand=1, qualifiers=None),
+          dict(base_first=flen + 101, base_last=flen + 200, name="Favorite", type="gene",
+               strand=1, qualifiers=dict(locus="Favorite", product="Favoritep")),
+          dict(base_first=flen + 201, base_last=flen + 250, name="tFavorite", type="terminator",
+               strand=1, qualifiers=None),
+          dict(base_first=flen + 251, base_last=flen + 300, name="tBest", type="terminator",
+               strand=-1, qualifiers=None),
+          dict(base_first=flen + 301, base_last=flen + 400, name="Best", type="gene",
+               strand=-1, qualifiers=dict(locus="Best", product="Bestp")),
+          dict(base_first=flen + 401, base_last=flen + 500, name="pBest", type="promoter",
+               strand=-1, qualifiers=None)
+        ]
+
+        res = self.client.post('/edge/genomes/%s/recombination/' % self.genome.id,
+                               data=json.dumps(dict(cassette=cassette,
+                                                    homology_arm_length=self.arm_len,
+                                                    create=True,
+                                                    annotations=annotations,
+                                                    genome_name='FooBar')),
+                               content_type='application/json')
+        self.assertEquals(res.status_code, 201)
+        r = json.loads(res.content)
+
+        c = Genome.objects.get(pk=r['id'])
+        f = c.fragments.all()[0].indexed_fragment()
+        annotations = f.annotations()
+        self.assertEquals(len(annotations), 7)
+
+    def test_does_not_annotate_if_donor_has_overhangs(self):
+        donor = "a" * 500
+        cassette = ''.join(["(gg/)", self.front_bs, donor, self.back_bs])
+        flen = len(self.front_bs)
+
+        annotations = [
+          dict(base_first=flen + 1,   base_last=flen + 100, name="pFavorite", type="promoter",
+               strand=1, qualifiers=None),
+          dict(base_first=flen + 101, base_last=flen + 200, name="Favorite", type="gene",
+               strand=1, qualifiers=dict(locus="Favorite", product="Favoritep")),
+          dict(base_first=flen + 201, base_last=flen + 250, name="tFavorite", type="terminator",
+               strand=1, qualifiers=None),
+          dict(base_first=flen + 251, base_last=flen + 300, name="tBest", type="terminator",
+               strand=-1, qualifiers=None),
+          dict(base_first=flen + 301, base_last=flen + 400, name="Best", type="gene",
+               strand=-1, qualifiers=dict(locus="Best", product="Bestp")),
+          dict(base_first=flen + 401, base_last=flen + 500, name="pBest", type="promoter",
+               strand=-1, qualifiers=None)
+        ]
+
+        res = self.client.post('/edge/genomes/%s/recombination/' % self.genome.id,
+                               data=json.dumps(dict(cassette=cassette,
+                                                    homology_arm_length=self.arm_len,
+                                                    create=True,
+                                                    annotations=annotations,
+                                                    genome_name='FooBar')),
+                               content_type='application/json')
+        self.assertEquals(res.status_code, 400)

--- a/src/edge/tests/test_recombine_annotations.py
+++ b/src/edge/tests/test_recombine_annotations.py
@@ -285,3 +285,21 @@ class GenomeRecombinationAnnotationsTest(TestCase):
         self.assertEquals(a.feature.strand, 1)
         self.assertEquals(a.base_first, len(self.upstream) + len(self.front_bs) + 1)
         self.assertEquals(a.base_last, len(self.upstream) + len(self.front_bs) + len(self.middle))
+
+    def test_preserves_annotations_on_homology_arm_fwd_that_have_not_changed(self):
+        self.assertEquals(True, False)
+
+    def test_preserves_annotations_on_homology_arm_rev_that_have_not_changed(self):
+        self.assertEquals(True, False)
+
+    def test_annotates_orf_in_reverse_cassette(self):
+        self.assertEquals(True, False)
+
+    def test_inherit_annotations_on_reverse_strand(self):
+        self.assertEquals(True, False)
+
+    def test_adds_annotations_on_fwd_strand(self):
+        self.assertEquals(True, False)
+
+    def test_adds_annotations_on_rev_strand(self):
+        self.assertEquals(True, False)

--- a/src/edge/tests/test_recombine_annotations.py
+++ b/src/edge/tests/test_recombine_annotations.py
@@ -472,3 +472,116 @@ class GenomeRecombinationAnnotationsTest(TestCase):
                                                     genome_name='FooBar')),
                                content_type='application/json')
         self.assertEquals(res.status_code, 400)
+        r = json.loads(res.content)
+        self.assertEquals("errors" in r, True)
+        self.assertEquals("does not have overhangs" in r["errors"], True)
+
+    def test_does_not_annotate_if_annotation_is_missing_field(self):
+        donor = "a" * 500
+        cassette = ''.join([self.front_bs, donor, self.back_bs])
+        flen = len(self.front_bs)
+
+        annotations = [
+          # missing base_first
+          dict(base_last=flen + 100, name="pFavorite", type="promoter",
+               strand=1, qualifiers=None),
+        ]
+
+        res = self.client.post('/edge/genomes/%s/recombination/' % self.genome.id,
+                               data=json.dumps(dict(cassette=cassette,
+                                                    homology_arm_length=self.arm_len,
+                                                    create=True,
+                                                    annotations=annotations,
+                                                    genome_name='FooBar')),
+                               content_type='application/json')
+        self.assertEquals(res.status_code, 400)
+        r = json.loads(res.content)
+        self.assertEquals("errors" in r, True)
+        self.assertEquals("have all the required field" in r["errors"], True)
+
+        annotations = [
+          # missing base_last
+          dict(base_first=flen + 1, name="pFavorite", type="promoter",
+               strand=1, qualifiers=None),
+        ]
+
+        res = self.client.post('/edge/genomes/%s/recombination/' % self.genome.id,
+                               data=json.dumps(dict(cassette=cassette,
+                                                    homology_arm_length=self.arm_len,
+                                                    create=True,
+                                                    annotations=annotations,
+                                                    genome_name='FooBar')),
+                               content_type='application/json')
+        self.assertEquals(res.status_code, 400)
+        r = json.loads(res.content)
+        self.assertEquals("errors" in r, True)
+        self.assertEquals("have all the required field" in r["errors"], True)
+
+        annotations = [
+          # missing name
+          dict(base_first=flen + 1, base_last=flen + 100, type="promoter",
+               strand=1, qualifiers=None),
+        ]
+
+        res = self.client.post('/edge/genomes/%s/recombination/' % self.genome.id,
+                               data=json.dumps(dict(cassette=cassette,
+                                                    homology_arm_length=self.arm_len,
+                                                    create=True,
+                                                    annotations=annotations,
+                                                    genome_name='FooBar')),
+                               content_type='application/json')
+        self.assertEquals(res.status_code, 400)
+        r = json.loads(res.content)
+        self.assertEquals("errors" in r, True)
+        self.assertEquals("have all the required field" in r["errors"], True)
+
+        annotations = [
+          # missing type
+          dict(base_first=flen + 1, base_last=flen + 100, name="pFavorite",
+               strand=1, qualifiers=None),
+        ]
+
+        res = self.client.post('/edge/genomes/%s/recombination/' % self.genome.id,
+                               data=json.dumps(dict(cassette=cassette,
+                                                    homology_arm_length=self.arm_len,
+                                                    create=True,
+                                                    annotations=annotations,
+                                                    genome_name='FooBar')),
+                               content_type='application/json')
+        self.assertEquals(res.status_code, 400)
+        r = json.loads(res.content)
+        self.assertEquals("errors" in r, True)
+        self.assertEquals("have all the required field" in r["errors"], True)
+
+        annotations = [
+          # missing strand
+          dict(base_first=flen + 1, base_last=flen + 100, name="pFavorite", type="promoter",
+               qualifiers=None),
+        ]
+
+        res = self.client.post('/edge/genomes/%s/recombination/' % self.genome.id,
+                               data=json.dumps(dict(cassette=cassette,
+                                                    homology_arm_length=self.arm_len,
+                                                    create=True,
+                                                    annotations=annotations,
+                                                    genome_name='FooBar')),
+                               content_type='application/json')
+        self.assertEquals(res.status_code, 400)
+        r = json.loads(res.content)
+        self.assertEquals("errors" in r, True)
+        self.assertEquals("have all the required field" in r["errors"], True)
+
+        annotations = [
+          # not missing anything
+          dict(base_first=flen + 1, base_last=flen + 100, name="pFavorite", type="promoter",
+               strand=1, qualifiers=None),
+        ]
+
+        res = self.client.post('/edge/genomes/%s/recombination/' % self.genome.id,
+                               data=json.dumps(dict(cassette=cassette,
+                                                    homology_arm_length=self.arm_len,
+                                                    create=True,
+                                                    annotations=annotations,
+                                                    genome_name='FooBar')),
+                               content_type='application/json')
+        self.assertEquals(res.status_code, 201)

--- a/src/edge/views.py
+++ b/src/edge/views.py
@@ -487,9 +487,10 @@ class GenomeOperationViewBase(ViewBase):
         args = parser.parse_args(request)
         create = args['create']
 
-        parsed = self.parse_arguments(request)
+        errors = []
+        parsed = self.parse_arguments(request, errors)
         if parsed is None:
-            return None, 400
+            return dict(errors=" ".join(errors)), 400
 
         args, op_class = parsed
         if create is False:
@@ -529,7 +530,7 @@ class GenomeOperationViewBase(ViewBase):
 
 class GenomeCrisprDSBView(GenomeOperationViewBase):
 
-    def parse_arguments(self, request):
+    def parse_arguments(self, request, errors):
         from edge.crispr import CrisprOp
 
         parser = RequestParser()
@@ -577,7 +578,7 @@ class GenomeRecombinationView(GenomeOperationViewBase):
         # donor sequence is
         return len(annotations) == 0
 
-    def parse_arguments(self, request):
+    def parse_arguments(self, request, errors):
         from edge.recombine import RecombineOp
 
         parser = RequestParser()
@@ -611,6 +612,11 @@ class GenomeRecombinationView(GenomeOperationViewBase):
         if annotations is None:
             annotations = []
         elif GenomeRecombinationView.validate_annotations(cassette, annotations) is False:
+            errors.append(
+                "Annotations failed validation: \
+please make sure donor sequence does not have overhangs \
+and annotation array elements have all the required fields"
+            )
             return None
 
         if homology_arm_length is None:

--- a/src/edge/views.py
+++ b/src/edge/views.py
@@ -1,5 +1,6 @@
-import json
 import os
+import re
+import json
 import random
 import tempfile
 
@@ -550,6 +551,28 @@ class GenomeCrisprDSBView(GenomeOperationViewBase):
 class GenomeRecombinationView(GenomeOperationViewBase):
     DEFAULT_HA_LENGTH = 30
 
+    @staticmethod
+    def validate_annotations(cassette, annotations):
+	"""
+	If user supplied annotations for the donor sequence, to make sure we
+	can precisely use the annotation and not leave any ambiguity, we
+	require the donor dna to not contain overhangs and backbone
+	modifications. This method returns True if that's the case, and
+        required fields for annotations exist.
+        """
+
+        if re.match(r'^[A-Za-z]$', cassette) and \
+           len([a for a in annotations if "base_first" not in a or \
+                                          "base_last" not in a or \
+                                          "name" not in a or \
+                                          "type" not in a or \
+                                          "strand" not in a]) == 0:
+            return True
+
+	# if there are no supplied annotations, we don't care what format the
+	# donor sequence is
+        return len(annotations) == 0
+
     def parse_arguments(self, request):
         from edge.recombine import RecombineOp
 
@@ -565,21 +588,29 @@ class GenomeRecombinationView(GenomeOperationViewBase):
         parser.add_argument('design_primers', field_type=bool, required=False,
                             default=False, location='json')
         parser.add_argument('primer3_opts', field_type=dict, required=False,
-                            default={}, location='json')
+                            default=None, location='json')
+        parser.add_argument('annotations', field_type=list, required=False,
+                            default=None, location='json')
 
         args = parser.parse_args(request)
-        cassette = args['cassette']
+        cassette = args['cassette'].strip()
         homology_arm_length = args['homology_arm_length']
         genome_name = args['genome_name']
         cassette_name = args['cassette_name']
         notes = args['notes']
         design_primers = args['design_primers']
         primer3_opts = args['primer3_opts']
+        annotations = args['annotations']
+        if primer3_opts is None:
+            primer3_opts = {}
+        if annotations is None:
+            annotations = []
 
         if homology_arm_length is None:
             homology_arm_length = GenomeRecombinationView.DEFAULT_HA_LENGTH
 
         return (dict(cassette=cassette, homology_arm_length=homology_arm_length,
                      genome_name=genome_name, cassette_name=cassette_name,
-                     notes=notes, design_primers=design_primers, primer3_opts=primer3_opts),
+                     notes=notes, design_primers=design_primers,
+                     primer3_opts=primer3_opts, annotations=annotations),
                 RecombineOp)

--- a/src/edge/views.py
+++ b/src/edge/views.py
@@ -615,7 +615,7 @@ class GenomeRecombinationView(GenomeOperationViewBase):
             errors.append(
                 "Annotations failed validation: \
 please make sure donor sequence does not have overhangs \
-and annotation array elements have all the required fields"
+and annotation array elements have all the required fields."
             )
             return None
 


### PR DESCRIPTION
This MR allows caller to specify annotations on the donor DNA, when doing a HR on a genome.