### PR TITLE
schedule task to build genome index if one is not available

### DIFF
--- a/src/edge/models/fragment.py
+++ b/src/edge/models/fragment.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.utils import timezone
 from django.db import models
 from django.db.models import Q
@@ -88,6 +89,7 @@ class Fragment(models.Model):
 
             return out_edges[0].to_chunk
 
+    @transaction.atomic()
     def index_fragment_chunk_locations(self):
         # remove old index
         self.fragment_chunk_location_set.all().delete()

--- a/src/edge/tasks.py
+++ b/src/edge/tasks.py
@@ -6,6 +6,12 @@ from django.db import transaction
 
 
 @shared_task
+def build_genome_fragment_indices(genome_id):
+    genome = Genome.objects.get(pk=genome_id)
+    genome.indexed_genome()
+
+
+@shared_task
 def build_genome_blastdb(genome_id):
     genome = Genome.objects.get(pk=genome_id)
     build_genome_db(genome, refresh=True)

--- a/src/edge/views.py
+++ b/src/edge/views.py
@@ -15,7 +15,7 @@ from django.db import transaction
 from edge.models import Fragment, Genome, Operation
 from edge.io import IO
 from edge import import_gff
-from edge.tasks import build_genome_blastdb
+from edge.tasks import build_genome_blastdb, build_genome_fragment_indices
 
 
 def genome_export(request, genome_id):
@@ -329,6 +329,10 @@ class GenomeAnnotationsView(ViewBase):
         q_parser.add_argument('field', field_type=str, required=False, default=None)
         args = q_parser.parse_args(request)
         field = args['field']
+
+        if not genome.has_location_index:
+            build_genome_fragment_indices.delay(genome.id)
+            return dict(error="Missing genome indices, building. Please check back later.")
 
         res = []
         if field is None:


### PR DESCRIPTION
This allows a GET request to the RO server to trigger a celery task to build genome index, if one does not exist. Currently if there's no genome index, the GET call fails, and the index is not built, so subsequent calls also fail.