### PR TITLE
Add ability to derive a new genome from adding a fragment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: git://github.com/PyCQA/flake8
+    rev: 3.7.8
+    hooks:
+    -   id: flake8

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,11 @@ RUN git config --global user.name "$GIT_USER_NAME" \
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
-RUN apt-get update
-RUN apt-get upgrade --assume-yes
-RUN apt-get install --assume-yes --verbose-versions \
+RUN apt-get update && apt-get install --assume-yes --verbose-versions \
   apt-utils \
   default-mysql-client \
   nodejs \
+  npm \
   ncbi-blast+ \
   primer3
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       AMQP_URL: 'amqp://guest@rabbit:5672//'
       FULLSTORY_ORG_ID: 'your_fullstory_org_id'
       FULLSTORY_URL: 'www.fullstory.com'
-    tty: true
 
   edge-db:
     image: mysql:5.7

--- a/src/edge/forms.py
+++ b/src/edge/forms.py
@@ -1,0 +1,6 @@
+from django import forms
+
+class FragmentForm(forms.Form):
+    name = forms.CharField()
+    sequence = forms.CharField()
+    circular = forms.BooleanField(required=False)

--- a/src/edge/forms.py
+++ b/src/edge/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 
+
 class FragmentForm(forms.Form):
     name = forms.CharField()
     sequence = forms.CharField()

--- a/src/edge/tests/test_views.py
+++ b/src/edge/tests/test_views.py
@@ -1,6 +1,7 @@
 import json
 import re
 
+from django import forms
 from django.test import TestCase
 from django.urls import reverse
 
@@ -35,13 +36,13 @@ class GenomeListTest(TestCase):
     def test_derives_new_genome_after_adding_fragment(self):
         g1 = Genome(name='Foo')
         g1.save()
-        url = reverse('derive-genome', kwargs={'genome_id': g1.id})
+        url = reverse('derive-genome-with-new-fragments', kwargs={'genome_id': g1.id})
         res = self.client.post(
             url,
-            data=json.dumps({
+            data=json.dumps([{
                 'name': 'test-fragment',
                 'sequence': 'AGCTAGCTTCGATCGA'
-            }),
+            }]),
             content_type='application/json',
         )
         self.assertEquals(res.status_code, 201)
@@ -59,6 +60,66 @@ class GenomeListTest(TestCase):
                 'parent_id': None,
                 'length': 16,
             }],
+            "id": child.id,
+            "name": child.name,
+            "notes": None,
+            "parent_id": g1.id,
+            "parent_name": g1.name,
+            "uri": '/edge/genomes/{}/'.format(child.id)
+        })
+
+    def test_doesnt_derives_new_genome_on_invalid_fragment(self):
+        g1 = Genome(name='Foo')
+        g1.save()
+        url = reverse('derive-genome-with-new-fragments', kwargs={'genome_id': g1.id})
+        with self.assertRaises(forms.ValidationError) as exception:
+            res = self.client.post(
+                url,
+                data=json.dumps([{
+                    'name': 'valid-fragment',
+                    'sequence': 'AGCTAGCTTCGATCGA'
+                }, {
+                    'name': 'invalid-fragment',
+                }]),
+                content_type='application/json',
+            )
+            self.assertIn('sequence', exception.exception.error_dict)
+
+        # Ensure that when an error is hit, no child genome was derived from the initially
+        # valid fragments
+        self.assertEqual(Genome.objects.filter(parent=g1.id).count(), 0)
+
+    def test_derives_new_genome_with_multiple_fragments(self):
+        g1 = Genome(name='Foo')
+        g1.save()
+        url = reverse('derive-genome-with-new-fragments', kwargs={'genome_id': g1.id})
+        res = self.client.post(
+            url,
+            data=json.dumps([{
+                'name': 'test-fragment',
+                'sequence': 'AGCTAGCTTCGATCGA'
+            }, {
+                'name': 'circular-fragment',
+                'sequence': 'AGCTAGCTTCGATCGAAGCTATTATATCGATA',
+                'circular': True
+            }]),
+            content_type='application/json',
+        )
+        self.assertEquals(res.status_code, 201)
+
+        child = Genome.objects.get(parent=g1.id)
+        self.assertNotEquals(child.id, g1.id)
+
+        fragments = [{
+                'id': fragment.id,
+                'uri': '/edge/fragments/{}/'.format(fragment.id),
+                'name': fragment.name,
+                'circular': fragment.circular,
+                'parent_id': None,
+                'length': fragment.indexed_fragment().length,
+            } for fragment in child.fragments.all()]
+        self.assertEquals(json.loads(res.content), {
+            "fragments": fragments,
             "id": child.id,
             "name": child.name,
             "notes": None,

--- a/src/edge/tests/test_views.py
+++ b/src/edge/tests/test_views.py
@@ -1,6 +1,8 @@
 import json
 import re
+
 from django.test import TestCase
+from django.urls import reverse
 
 from edge.models import Genome, Fragment, Genome_Fragment
 
@@ -28,6 +30,41 @@ class GenomeListTest(TestCase):
             "parent_id": None,
             "parent_name": '',
             "uri": uri
+        })
+
+    def test_derives_new_genome_after_adding_fragment(self):
+        g1 = Genome(name='Foo')
+        g1.save()
+        url = reverse('derive-genome', kwargs={'genome_id': g1.id})
+        res = self.client.post(
+            url,
+            data=json.dumps({
+                'name': 'test-fragment',
+                'sequence': 'AGCTAGCTTCGATCGA'
+            }),
+            content_type='application/json',
+        )
+        self.assertEquals(res.status_code, 201)
+
+        child = Genome.objects.get(parent=g1.id)
+        self.assertNotEquals(child.id, g1.id)
+
+        fragment = child.fragments.first()
+        self.assertEquals(json.loads(res.content), {
+            "fragments": [{
+                'id': fragment.id,
+                'uri': '/edge/fragments/{}/'.format(fragment.id),
+                'name': fragment.name,
+                'circular': fragment.circular,
+                'parent_id': None,
+                'length': 16,
+            }],
+            "id": child.id,
+            "name": child.name,
+            "notes": None,
+            "parent_id": g1.id,
+            "parent_name": g1.name,
+            "uri": '/edge/genomes/{}/'.format(child.id)
         })
 
     def test_can_use_uri_from_add_genome_to_fetch_genome(self):

--- a/src/edge/tests/test_views.py
+++ b/src/edge/tests/test_views.py
@@ -73,7 +73,7 @@ class GenomeListTest(TestCase):
         g1.save()
         url = reverse('derive-genome-with-new-fragments', kwargs={'genome_id': g1.id})
         with self.assertRaises(forms.ValidationError) as exception:
-            res = self.client.post(
+            self.client.post(
                 url,
                 data=json.dumps([{
                     'name': 'valid-fragment',

--- a/src/edge/urls.py
+++ b/src/edge/urls.py
@@ -51,7 +51,11 @@ urlpatterns = [
     url(r'^genomes/(?P<genome_id>\d+)/recombination/$', GenomeRecombinationView.as_view()),
     url(r'^genomes/(?P<genome_id>\d+)/crispr/dsb/$', GenomeCrisprDSBView.as_view()),
 
-    url(r'^genomes/(?P<genome_id>\d+)/derive-genome-with-new-fragments/$', GenomeDeriveView.as_view(), name='derive-genome-with-new-fragments'),
+    url(
+        r'^genomes/(?P<genome_id>\d+)/derive-genome-with-new-fragments/$',
+        GenomeDeriveView.as_view(),
+        name='derive-genome-with-new-fragments',
+    ),
 
     url(r'^genomes/(?P<genome_id>\d+)/export/$', genome_export),
 ]

--- a/src/edge/urls.py
+++ b/src/edge/urls.py
@@ -6,6 +6,7 @@ from edge.views import (
     FragmentListView,
     FragmentSequenceView,
     FragmentAnnotationsView,
+    GenomeDeriveView,
     GenomeView,
     GenomeListView,
     GenomeAnnotationsView,
@@ -49,6 +50,8 @@ urlpatterns = [
     url(r'^genomes/(?P<genome_id>\d+)/pcr/$', GenomePcrView.as_view()),
     url(r'^genomes/(?P<genome_id>\d+)/recombination/$', GenomeRecombinationView.as_view()),
     url(r'^genomes/(?P<genome_id>\d+)/crispr/dsb/$', GenomeCrisprDSBView.as_view()),
+
+    url(r'^genomes/(?P<genome_id>\d+)/derive/$', GenomeDeriveView.as_view(), name='derive-genome'),
 
     url(r'^genomes/(?P<genome_id>\d+)/export/$', genome_export),
 ]

--- a/src/edge/urls.py
+++ b/src/edge/urls.py
@@ -51,7 +51,7 @@ urlpatterns = [
     url(r'^genomes/(?P<genome_id>\d+)/recombination/$', GenomeRecombinationView.as_view()),
     url(r'^genomes/(?P<genome_id>\d+)/crispr/dsb/$', GenomeCrisprDSBView.as_view()),
 
-    url(r'^genomes/(?P<genome_id>\d+)/derive/$', GenomeDeriveView.as_view(), name='derive-genome'),
+    url(r'^genomes/(?P<genome_id>\d+)/derive-genome-with-new-fragments/$', GenomeDeriveView.as_view(), name='derive-genome-with-new-fragments'),
 
     url(r'^genomes/(?P<genome_id>\d+)/export/$', genome_export),
 ]

--- a/src/edge/views.py
+++ b/src/edge/views.py
@@ -362,6 +362,17 @@ class GenomeFragmentListView(ViewBase):
         return FragmentView.to_dict(fragment), 201
 
 
+class GenomeDeriveView(ViewBase):
+
+    @transaction.atomic()
+    def on_post(self, request, genome_id):
+        genome = get_genome_or_404(genome_id)
+        child = genome.update()
+        args = fragment_parser.parse_args(request)
+        child.add_fragment(args['name'], args['sequence'], circular=args['circular'])
+        return GenomeView.to_dict(child), 201
+
+
 class GenomeListView(ViewBase):
 
     def on_get(self, request):


### PR DESCRIPTION
This is to support random integrations with a new genome. A new genome is created, with a fragment that is not localized, but still listed as part of the genome. In the future, there will be a system where the user can localize the insert and derive yet another new genome.