### PR TITLE
return feature information, along with annotations

### DIFF
--- a/src/edge/tests/test_views.py
+++ b/src/edge/tests/test_views.py
@@ -4,7 +4,7 @@ import re
 from django import forms
 from django.test import TestCase
 from django.urls import reverse
-
+import unittest.mock as mock
 from edge.models import Genome, Fragment, Genome_Fragment
 
 
@@ -532,13 +532,20 @@ class FragmentTest(TestCase):
                 {
                     "base_first": 2,
                     "base_last": 9,
-                    "name": "proC",
-                    "type": "promoter",
                     "strand": 1,
-                    "qualifiers": {},
-                    "feature_full_length": 8,
                     "feature_base_first": 1,
                     "feature_base_last": 8,
+                    "feature": {
+                        "id": mock.ANY,
+                        "length": 8,
+                        "name": "proC",
+                        "type": "promoter",
+                        "qualifiers": {}
+                    },
+                    "name": "proC",
+                    "type": "promoter",
+                    "feature_full_length": 8,
+                    "qualifiers": {},
                 }
             ],
         )
@@ -566,13 +573,20 @@ class FragmentTest(TestCase):
                 {
                     "base_first": 2,
                     "base_last": 9,
-                    "name": "proC",
-                    "type": "promoter",
                     "strand": 1,
-                    "qualifiers": {"gene": "PROC"},
-                    "feature_full_length": 8,
                     "feature_base_first": 1,
                     "feature_base_last": 8,
+                    "feature": {
+                        "id": mock.ANY,
+                        "length": 8,
+                        "name": "proC",
+                        "type": "promoter",
+                        "qualifiers": {"gene": "PROC"}
+                    },
+                    "name": "proC",
+                    "type": "promoter",
+                    "qualifiers": {"gene": "PROC"},
+                    "feature_full_length": 8,
                 }
             ],
         )
@@ -593,13 +607,20 @@ class FragmentTest(TestCase):
                 {
                     "base_first": 3,
                     "base_last": 10,
-                    "name": "proC",
-                    "type": "promoter",
                     "strand": -1,
-                    "qualifiers": {},
-                    "feature_full_length": 8,
                     "feature_base_first": 1,
                     "feature_base_last": 8,
+                    "feature": {
+                        "id": mock.ANY,
+                        "length": 8,
+                        "name": "proC",
+                        "type": "promoter",
+                        "qualifiers": {}
+                    },
+                    "name": "proC",
+                    "type": "promoter",
+                    "qualifiers": {},
+                    "feature_full_length": 8,
                 }
             ],
         )
@@ -628,24 +649,38 @@ class FragmentTest(TestCase):
                 {
                     "base_first": 2,
                     "base_last": 4,
-                    "name": "proC",
-                    "type": "promoter",
                     "strand": 1,
-                    "qualifiers": {"gene": "PROC"},
-                    "feature_full_length": 7,
                     "feature_base_first": 1,
                     "feature_base_last": 3,
+                    "feature": {
+                        "id": mock.ANY,
+                        "length": 7,
+                        "name": "proC",
+                        "type": "promoter",
+                        "qualifiers": {"gene": "PROC"}
+                    },
+                    "name": "proC",
+                    "type": "promoter",
+                    "qualifiers": {"gene": "PROC"},
+                    "feature_full_length": 7,
                 },
                 {
                     "base_first": 6,
                     "base_last": 9,
-                    "name": "proC",
-                    "type": "promoter",
                     "strand": 1,
-                    "qualifiers": {"gene": "PROC"},
-                    "feature_full_length": 7,
                     "feature_base_first": 4,
                     "feature_base_last": 7,
+                    "feature": {
+                        "id": mock.ANY,
+                        "length": 7,
+                        "name": "proC",
+                        "type": "promoter",
+                        "qualifiers": {"gene": "PROC"}
+                    },
+                    "name": "proC",
+                    "type": "promoter",
+                    "qualifiers": {"gene": "PROC"},
+                    "feature_full_length": 7,
                 },
             ],
         )
@@ -668,24 +703,38 @@ class FragmentTest(TestCase):
                 {
                     "base_first": 2,
                     "base_last": 9,
-                    "name": "proC",
-                    "type": "promoter",
                     "strand": 1,
-                    "qualifiers": {},
-                    "feature_full_length": 8,
                     "feature_base_first": 1,
                     "feature_base_last": 8,
+                    "feature": {
+                        "id": mock.ANY,
+                        "length": 8,
+                        "name": "proC",
+                        "type": "promoter",
+                        "qualifiers": {}
+                    },
+                    "name": "proC",
+                    "type": "promoter",
+                    "qualifiers": {},
+                    "feature_full_length": 8,
                 },
                 {
                     "base_first": 3,
                     "base_last": 10,
-                    "name": "proD",
-                    "type": "promoter",
                     "strand": -1,
-                    "qualifiers": {},
-                    "feature_full_length": 8,
                     "feature_base_first": 1,
                     "feature_base_last": 8,
+                    "feature": {
+                        "id": mock.ANY,
+                        "length": 8,
+                        "name": "proD",
+                        "type": "promoter",
+                        "qualifiers": {}
+                    },
+                    "name": "proD",
+                    "type": "promoter",
+                    "qualifiers": {},
+                    "feature_full_length": 8,
                 },
             ],
         )
@@ -710,24 +759,38 @@ class FragmentTest(TestCase):
                 {
                     "base_first": 2,
                     "base_last": 8,
-                    "name": "proC",
-                    "type": "promoter",
                     "strand": 1,
-                    "qualifiers": {},
-                    "feature_full_length": 7,
                     "feature_base_first": 1,
                     "feature_base_last": 7,
+                    "feature": {
+                        "id": mock.ANY,
+                        "length": 7,
+                        "name": "proC",
+                        "type": "promoter",
+                        "qualifiers": {}
+                    },
+                    "name": "proC",
+                    "type": "promoter",
+                    "qualifiers": {},
+                    "feature_full_length": 7,
                 },
                 {
                     "base_first": 10,
                     "base_last": 13,
-                    "name": "proD",
-                    "type": "promoter",
                     "strand": -1,
-                    "qualifiers": {},
-                    "feature_full_length": 4,
                     "feature_base_first": 1,
                     "feature_base_last": 4,
+                    "feature": {
+                        "id": mock.ANY,
+                        "length": 4,
+                        "name": "proD",
+                        "type": "promoter",
+                        "qualifiers": {}
+                    },
+                    "name": "proD",
+                    "type": "promoter",
+                    "qualifiers": {},
+                    "feature_full_length": 4,
                 },
             ],
         )
@@ -739,24 +802,38 @@ class FragmentTest(TestCase):
                 {
                     "base_first": 2,
                     "base_last": 8,
-                    "name": "proC",
-                    "type": "promoter",
+                    "feature": {
+                        "id": mock.ANY,
+                        "length": 7,
+                        "name": "proC",
+                        "type": "promoter",
+                        "qualifiers": {}
+                    },
                     "strand": 1,
-                    "qualifiers": {},
-                    "feature_full_length": 7,
                     "feature_base_first": 1,
                     "feature_base_last": 7,
+                    "name": "proC",
+                    "type": "promoter",
+                    "qualifiers": {},
+                    "feature_full_length": 7,
                 },
                 {
                     "base_first": 10,
                     "base_last": 13,
-                    "name": "proD",
-                    "type": "promoter",
                     "strand": -1,
-                    "qualifiers": {},
-                    "feature_full_length": 4,
                     "feature_base_first": 1,
                     "feature_base_last": 4,
+                    "feature": {
+                        "id": mock.ANY,
+                        "length": 4,
+                        "name": "proD",
+                        "type": "promoter",
+                        "qualifiers": {}
+                    },
+                    "name": "proD",
+                    "type": "promoter",
+                    "qualifiers": {},
+                    "feature_full_length": 4,
                 },
             ],
         )
@@ -768,13 +845,20 @@ class FragmentTest(TestCase):
                 {
                     "base_first": 10,
                     "base_last": 13,
-                    "name": "proD",
-                    "type": "promoter",
                     "strand": -1,
-                    "qualifiers": {},
-                    "feature_full_length": 4,
                     "feature_base_first": 1,
                     "feature_base_last": 4,
+                    "feature": {
+                        "id": mock.ANY,
+                        "length": 4,
+                        "name": "proD",
+                        "type": "promoter",
+                        "qualifiers": {}
+                    },
+                    "name": "proD",
+                    "type": "promoter",
+                    "qualifiers": {},
+                    "feature_full_length": 4,
                 }
             ],
         )
@@ -873,13 +957,20 @@ class GenomeAnnotationsTest(TestCase):
                         {
                             "base_first": 2,
                             "base_last": 9,
-                            "name": "proC",
-                            "type": "promoter",
+                            "feature": {
+                                "id": mock.ANY,
+                                "length": 8,
+                                "name": "proC",
+                                "type": "promoter",
+                                "qualifiers": {}
+                            },
                             "strand": 1,
-                            "qualifiers": {},
-                            "feature_full_length": 8,
                             "feature_base_first": 1,
                             "feature_base_last": 8,
+                            "name": "proC",
+                            "type": "promoter",
+                            "qualifiers": {},
+                            "feature_full_length": 8,
                         }
                     ],
                 ]
@@ -915,7 +1006,7 @@ class GenomeAnnotationsTest(TestCase):
         url = reverse("genome_annotations", kwargs=dict(genome_id=self.genome_id))
         res = self.client.get("%s?q=Atg20p&field=product" % url)
         self.assertEquals(res.status_code, 200)
-        print(json.loads(res.content))
+        print(json.loads(res.content)[0])
         self.assertEquals(
             json.loads(res.content),
             [
@@ -925,13 +1016,20 @@ class GenomeAnnotationsTest(TestCase):
                         {
                             "base_first": 5,
                             "base_last": 7,
-                            "name": "Another annotation",
-                            "type": "promoter",
+                            "feature": {
+                                "id": mock.ANY,
+                                "length": 3,
+                                "name": "Another annotation",
+                                "type": "promoter",
+                                "qualifiers": {"product": ["Atg20p"]}
+                            },
                             "strand": 1,
-                            "qualifiers": {"product": ["Atg20p"]},
-                            "feature_full_length": 3,
                             "feature_base_first": 1,
                             "feature_base_last": 3,
+                            "name": "Another annotation",
+                            "type": "promoter",
+                            "qualifiers": {"product": ["Atg20p"]},
+                            "feature_full_length": 3,
                         }
                     ],
                 ]

--- a/src/edge/views.py
+++ b/src/edge/views.py
@@ -145,6 +145,7 @@ class FragmentView(ViewBase):
         length = fragment.est_length
         if compute_length is True and fragment.has_location_index:
             length = fragment.indexed_fragment().length
+
         return dict(
             id=fragment.id,
             uri=reverse("fragment", kwargs=dict(fragment_id=fragment.id)),
@@ -183,13 +184,20 @@ class FragmentAnnotationsView(ViewBase):
         return dict(
             base_first=annotation.base_first,
             base_last=annotation.base_last,
-            name=annotation.feature.name,
-            type=annotation.feature.type,
             strand=annotation.feature.strand,
-            qualifiers=annotation.feature.qualifiers,
-            feature_full_length=annotation.feature.length,
             feature_base_first=annotation.feature_base_first,
             feature_base_last=annotation.feature_base_last,
+            feature=dict(id=annotation.feature.id,
+                         name=annotation.feature.name,
+                         type=annotation.feature.type,
+                         length=annotation.feature.length,
+                         qualifiers=annotation.feature.qualifiers),
+            # below fields are for backwards compatibility only, repeated in
+            # the .feature dictionary
+            name=annotation.feature.name,
+            type=annotation.feature.type,
+            qualifiers=annotation.feature.qualifiers,
+            feature_full_length=annotation.feature.length
         )
 
     def on_get(self, request, fragment_id):


### PR DESCRIPTION
When returning annotations, the JSON format should include feature information, such as feature ID, feature name, etc. This allows callers to determine if two annotations from different parts of the genome belong to the same feature (e.g. exons) or not.