### PR TITLE
Update FullStory CDN link, recording snippet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update && apt-get install --assume-yes --verbose-versions \
   apt-utils \
   default-mysql-client \
   nodejs \
-  npm \
   ncbi-blast+ \
   primer3
 

--- a/src/edge/templates/edge/edge.html
+++ b/src/edge/templates/edge/edge.html
@@ -28,7 +28,7 @@
     <script>
       window["_fs_debug"] = false;
       window["_fs_host"] = "{{ FULLSTORY_URL }}";
-      window["_fs_script"] = "fullstory.com/s/fs.js";
+      window["_fs_script"] = "edge.fullstory.com/s/fs.js";
       window["_fs_org"] = "{{ FULLSTORY_ORG_ID }}";
       window["_fs_namespace"] = "FS";
       (function(m, n, e, t, l, o, g, y) {
@@ -60,6 +60,9 @@
         g.event = function(i, v, s) {
           g("event", { n: i, p: v }, s);
         };
+        g.anonymize = function() {
+          g.identify(!!0);
+        };
         g.shutdown = function() {
           g("rec", !1);
         };
@@ -79,6 +82,19 @@
           g(o, v);
         };
         g.clearUserCookie = function() {};
+        g.setVars = function(n, p) {
+          g("setVars", [n, p]);
+        };
+        g._w = {};
+        y = "XMLHttpRequest";
+        g._w[y] = m[y];
+        y = "fetch";
+        g._w[y] = m[y];
+        if (m[y])
+          m[y] = function() {
+            return g._w[y].apply(this, arguments);
+          };
+        g._v = "1.3.0";
       })(window, document, window["_fs_namespace"], "script", "user");
     </script>
   </head>


### PR DESCRIPTION
Per the following:

> Beginning July 13, 2021 legacy versions of the snippet pointing to https://fullstory.com/s/fs.js and https://www.fullstory.com/s/fs.js will no longer redirect to https://edge.fullstory.com/s/fs.js. As a result, recording will stop if you have not updated your snippet by this date. 
https://help.fullstory.com/hc/en-us/articles/360041242094-FullStory-on-a-CDN

The recording snippet provided us by FullStory looks like it also includes several other minor changes. That accounts for the rest of the diff.