### PR TITLE
Include Subfeatures in GFF Export

### DIFF
--- a/src/edge/importer.py
+++ b/src/edge/importer.py
@@ -1,4 +1,4 @@
-import time, hashlib
+import time
 
 from BCBio import GFF
 from django.db import connection
@@ -194,7 +194,6 @@ class GFFFragmentImporter(object):
                                 features.append(sub_sub_tup)
                                 self.__subfeatures_dict[subsubfeature_name] = [sub_sub_tup]
 
-
         self.__features = features
 
         # update features made from only subfeatures
@@ -294,14 +293,15 @@ class GFFFragmentImporter(object):
             for subfeature in self.__subfeatures_dict[f_name]:
                 sf_start, sf_end, sf_name, sf_type, sf_strand, sf_qualifiers = subfeature
                 self._annotate_feature(
-                    fragment, sf_start, sf_end, sf_name, sf_type, sf_strand, sf_qualifiers, 
-                    feature=new_feature, feature_base_first=sf_start-f_start+1
+                    fragment, sf_start, sf_end, sf_name, sf_type, sf_strand, sf_qualifiers,
+                    feature=new_feature, feature_base_first=sf_start - f_start + 1
                 )
             print("annotate feature: %.4f\r" % (time.time() - t0,), end="")
         print("\nfinished annotating feature")
 
     def _annotate_feature(
-        self, fragment, first_base1, last_base1, name, type, strand, qualifiers, feature=None, feature_base_first=1
+        self, fragment, first_base1, last_base1, name, type, strand, qualifiers,
+        feature=None, feature_base_first=1
     ):
         if fragment.circular and last_base1 < first_base1:
             # has to figure out the total length from last chunk
@@ -313,7 +313,7 @@ class GFFFragmentImporter(object):
 
         if first_base1 not in self.__fclocs or (
             (last_base1 < len(self.__sequence) and last_base1 + 1 not in self.__fclocs)) or (
-            last_base1 > len(self.__sequence)):
+                last_base1 > len(self.__sequence)):
             raise Exception(
                 "Cannot find appropriate sequence for feature: %s, start %s, end %s"
                 % (name, first_base1, last_base1)
@@ -333,14 +333,14 @@ class GFFFragmentImporter(object):
 
         new_feature = fragment._add_feature(
             name, type, length, strand, qualifiers
-        ) if feature == None else feature
-            
-        if feature != None or self.__subfeatures_dict[name] == []:
+        ) if feature is None else feature
+
+        if feature is not None or self.__subfeatures_dict[name] == []:
             for first_base1, last_base1 in bases:
                 region_length = fragment.bp_covered_length(first_base1, last_base1)
                 fragment.annotate_chunk(
                     new_feature, feature_base_first, first_base1, last_base1
                 )
                 feature_base_first += region_length
-        
+
         return new_feature

--- a/src/edge/io.py
+++ b/src/edge/io.py
@@ -53,12 +53,16 @@ class IO(object):
                     qualifiers["Phase"] = 0
 
                 qualifiers.update({"name": annotation.feature_name})
+                qualifiers_copy = {key: qualifiers[key] for key in qualifiers if key != 'subfeature_qualifiers'}
+                sf_hash = f"{annotation.base_first}_{annotation.base_last}"
+                if 'subfeature_qualifiers' in qualifiers and sf_hash in qualifiers['subfeature_qualifiers']:
+                    qualifiers_copy = qualifiers['subfeature_qualifiers'][sf_hash]
                 strand = annotation.feature.strand
                 feature = SeqFeature(
                     loc,
                     type=annotation.feature.type,
                     strand=0 if strand is None else strand,
-                    qualifiers=qualifiers,
+                    qualifiers=qualifiers_copy,
                 )
                 features.append(feature)
 

--- a/src/edge/io.py
+++ b/src/edge/io.py
@@ -53,9 +53,11 @@ class IO(object):
                     qualifiers["Phase"] = 0
 
                 qualifiers.update({"name": annotation.feature_name})
-                qualifiers_copy = {key: qualifiers[key] for key in qualifiers if key != 'subfeature_qualifiers'}
+                qualifiers_copy = {
+                    key: qualifiers[key] for key in qualifiers if key != 'subfeature_qualifiers'}
                 sf_hash = f"{annotation.base_first}_{annotation.base_last}"
-                if 'subfeature_qualifiers' in qualifiers and sf_hash in qualifiers['subfeature_qualifiers']:
+                if 'subfeature_qualifiers' in qualifiers and \
+                        sf_hash in qualifiers['subfeature_qualifiers']:
                     qualifiers_copy = qualifiers['subfeature_qualifiers'][sf_hash]
                 strand = annotation.feature.strand
                 feature = SeqFeature(

--- a/src/edge/recombine.py
+++ b/src/edge/recombine.py
@@ -1014,9 +1014,9 @@ class RecombineOp(object):
             annotations=annotations,
         )
 
-	# some fragment indices may be destroyed because we had to split up
-	# existing chunks, rebuild them, so that parent genome is immediately
-	# reusable in an RO server
+    # some fragment indices may be destroyed because we had to split up
+    # existing chunks, rebuild them, so that parent genome is immediately
+    # reusable in an RO server
         genome.indexed_genome()
 
         return new_genome

--- a/src/edge/tests/test_importer.py
+++ b/src/edge/tests/test_importer.py
@@ -398,19 +398,8 @@ ACAGCCCTAATCTAACCCTGGCCAACCTGTCTCTCAACTTACCCTCCATTACCCTGCCTCCACTCGTTACCCTGTCCCAT
         self.assertEquals(len(chrI.annotations()), 1)
         self.assertEquals(chrI.annotations()[0].feature.name, "cds")
 
-class JoinImporterTest(TestCase):
-    """
-    Example
-    -------
-    U00096.3	feature	gene	57364	58179	.	+	.	db_xref=EcoGene:EG11570;gene=djlA;gene_synonym=ECK0056,JW0054,yabH;locus_tag=b0055
-    U00096.3	feature	CDS	57364	58179	.	+	0	codon_start=1;db_xref=GI:1786241,ASAP:ABE-0000187,UniProtKB/Swiss-Prot:P31680,EcoGene:EG11570;function=phenotype%3B Not classified;gene=djlA;gene_synonym=ECK0056,JW0054,yabH;locus_tag=b0055;note=GO_process: GO:0006457 - protein folding;product=DnaJ-like protein%2C membrane anchored;protein_id=AAC73166.1;transl_table=11;translation=MQYWGKIIGVAVALLMGGGFWGVVLGLLIGHMFDKARSRKMAWFANQRERQALFFATTFEVMGHLTKSKGRVTEADIHIASQLMDRMNLHGASRTAAQNAFRVGKSDNYPLREKMRQFRSVCFGRFDLIRMFLEIQIQAAFADGSLHPNERAVLYVIAEELGISRAQFDQFLRMMQGGAQFGGGYQQQTGGGNWQQAQRGPTLEDACNVLGVKPTDDATTIKRAYRKLMSEHHPDKLVAKGLPPEMMEMAKQKAQEIQQAYELIKQQKGFK
-    U00096.3	feature	gene	58474	59269	.	+	.	db_xref=EcoGene:EG12610;gene=yabP;gene_synonym=ECK0057,JW0055,yabQ;locus_tag=b4659;pseudo=
-    U00096.3	feature	CDS	58474	59269	.	+	0	ID=biopygen1;codon_start=1;db_xref=ASAP:ABE-0000192,ASAP:ABE-0000194,UniProtKB/Swiss-Prot:P39220,EcoGene:EG12610;gene=yabP;gene_synonym=ECK0057,JW0055,yabQ;locus_tag=b4659;note=pseudogene;pseudo=;transl_table=11
-    U00096.3	feature	CDS	58474	59052	.	+	0	Parent=biopygen1
-    U00096.3	feature	CDS	59052	59228	.	+	0	Parent=biopygen1
-    U00096.3	feature	CDS	59228	59269	.	+	0	Parent=biopygen1
-    """
 
+class JoinImporterTest(TestCase):
     def test_import_gff_CDS_subfragments(self):
 
         data = """##gff-version 3
@@ -515,8 +504,6 @@ ACAGCCCTAATCTAACCCTGGCCAACCTGTCTCTCAACTTACCCTCCATTACCCTGCCTCCACTCGTTACCCTGTCCCAT
         self.assertEqual(chrI.annotations()[2].feature.id, chrI.annotations()[3].feature.id)
         self.assertEqual(chrI.annotations()[3].feature.id, chrI.annotations()[4].feature.id)
 
-
-
     @mock.patch("edge.models.fragment.Annotation.from_chunk_feature_and_location_array")
     def test_import_gff_CDS_subfragments_overlap_check_chunks(self, cf_fcl_mock):
         data = """##gff-version 3
@@ -560,7 +547,7 @@ ACAGCCCTAATCTAACCCTGGCCAACCTGTCTCTCAACTTACCCTCCATTACCCTGCCTCCACTCGTTACCCTGTCCCAT
         gene_chunk_ends = sorted([cf.fcl_base_last for cf in gene_cfs])
         cds_chunk_starts = sorted([cf.fcl_base_first for cf in cds_cfs])
         cds_chunk_ends = sorted([cf.fcl_base_last for cf in cds_cfs])
-    
+
         self.assertEqual(len(chrI.sequence), 160)
         self.assertEqual(gene_chunk_starts, [30, 41, 42, 51, 56, 60, 62])
         self.assertEqual(gene_chunk_ends, [40, 41, 50, 55, 59, 61, 80])

--- a/src/edge/tests/test_io.py
+++ b/src/edge/tests/test_io.py
@@ -238,9 +238,12 @@ Bar\tfeature\tCDS\t2\t9\t.\t+\t0\taliases=foo,bar;foo=blah;locus_tag=b0002;name=
 
     def test_outputs_gff_subfeatures_with_qualifiers(self):
         fragment = self.fragment.indexed_fragment()
-        quals = dict(locus_tag="b0002", foo=["blah"], aliases=["foo", "bar"],
-                subfeature_qualifiers={"2_4": dict(Parent="A1", Name="A1_exon"), 
-                "5_6": dict(Parent="A1", Name="A1_intron"), "7_9": dict(Parent="A1", Name="A1_exon")})
+        quals = dict(
+            locus_tag="b0002", foo=["blah"], aliases=["foo", "bar"],
+            subfeature_qualifiers={
+                "2_4": dict(Parent="A1", Name="A1_exon"),
+                "5_6": dict(Parent="A1", Name="A1_intron"),
+                "7_9": dict(Parent="A1", Name="A1_exon")})
         fragment.annotate(
             2,
             9,
@@ -299,9 +302,12 @@ Bar\tfeature\tCDS\t7\t9\t.\t+\t0\tName=A1_exon;Parent=A1
 
     def test_outputs_reverse_gff_subfeatures_with_qualifiers(self):
         fragment = self.fragment.indexed_fragment()
-        quals = dict(locus_tag="b0002", foo=["blah"], aliases=["foo", "bar"],
-                subfeature_qualifiers={"2_4": dict(Parent="A1", Name="A1_exon"), 
-                "5_6": dict(Parent="A1", Name="A1_intron"), "7_9": dict(Parent="A1", Name="A1_exon")})
+        quals = dict(
+            locus_tag="b0002", foo=["blah"], aliases=["foo", "bar"],
+            subfeature_qualifiers={
+                "2_4": dict(Parent="A1", Name="A1_exon"),
+                "5_6": dict(Parent="A1", Name="A1_intron"),
+                "7_9": dict(Parent="A1", Name="A1_exon")})
         fragment.annotate(
             2,
             9,
@@ -360,8 +366,10 @@ Bar\tfeature\tCDS\t7\t9\t.\t-\t0\tName=A1_exon;Parent=A1
 
     def test_outputs_overlap_gff_subfeatures_with_qualifiers(self):
         fragment = self.fragment.indexed_fragment()
-        quals = dict(locus_tag="b0002", foo=["blah"], aliases=["foo", "bar"],
-                subfeature_qualifiers={"2_6": dict(Parent="A1", Name="A1_exon"), 
+        quals = dict(
+            locus_tag="b0002", foo=["blah"], aliases=["foo", "bar"],
+            subfeature_qualifiers={
+                "2_6": dict(Parent="A1", Name="A1_exon"),
                 "5_9": dict(Parent="A1", Name="A1_exon")})
         fragment.annotate(
             2,

--- a/src/edge/tests/test_io.py
+++ b/src/edge/tests/test_io.py
@@ -296,3 +296,125 @@ Bar\tfeature\tCDS\t7\t9\t.\t+\t0\tName=A1_exon;Parent=A1
             fragment.sequence,
         )
         self.assertEqual(expected, gff)
+
+    def test_outputs_reverse_gff_subfeatures_with_qualifiers(self):
+        fragment = self.fragment.indexed_fragment()
+        quals = dict(locus_tag="b0002", foo=["blah"], aliases=["foo", "bar"],
+                subfeature_qualifiers={"2_4": dict(Parent="A1", Name="A1_exon"), 
+                "5_6": dict(Parent="A1", Name="A1_intron"), "7_9": dict(Parent="A1", Name="A1_exon")})
+        fragment.annotate(
+            2,
+            9,
+            "A1",
+            "CDS",
+            -1,
+            qualifiers=quals,
+        )
+        fragment.annotate(
+            2,
+            4,
+            "A1_exon",
+            "CDS",
+            -1,
+            qualifiers=quals,
+        )
+        fragment.annotate(
+            5,
+            6,
+            "A1_intron",
+            "CDS",
+            -1,
+            qualifiers=quals,
+        )
+        fragment.annotate(
+            7,
+            9,
+            "A1_exon",
+            "CDS",
+            -1,
+            qualifiers=quals,
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w+", delete=False) as f:
+            f.close()
+            IO(self.genome).to_gff(f.name)
+            filehandle = open(f.name, "r")
+            gff = filehandle.read()
+            filehandle.close()
+            os.unlink(f.name)
+
+        # be aware of the tabs in the string below
+        expected = """##gff-version 3
+##sequence-region Bar 1 13
+Bar\tfeature\tCDS\t2\t9\t.\t-\t0\taliases=foo,bar;foo=blah;locus_tag=b0002;name=A1
+Bar\tfeature\tCDS\t2\t4\t.\t-\t0\tName=A1_exon;Parent=A1
+Bar\tfeature\tCDS\t5\t6\t.\t-\t0\tName=A1_intron;Parent=A1
+Bar\tfeature\tCDS\t7\t9\t.\t-\t0\tName=A1_exon;Parent=A1
+##FASTA
+>Bar <unknown description>
+%s
+""" % (
+            fragment.sequence,
+        )
+        self.assertEqual(expected, gff)
+
+    def test_outputs_overlap_gff_subfeatures_with_qualifiers(self):
+        fragment = self.fragment.indexed_fragment()
+        quals = dict(locus_tag="b0002", foo=["blah"], aliases=["foo", "bar"],
+                subfeature_qualifiers={"2_6": dict(Parent="A1", Name="A1_exon"), 
+                "5_9": dict(Parent="A1", Name="A1_exon")})
+        fragment.annotate(
+            2,
+            9,
+            "A1g",
+            "gene",
+            1,
+            qualifiers={},
+        )
+        fragment.annotate(
+            2,
+            9,
+            "A1",
+            "CDS",
+            1,
+            qualifiers=quals,
+        )
+        fragment.annotate(
+            2,
+            6,
+            "A1_exon",
+            "CDS",
+            1,
+            qualifiers=quals,
+        )
+        fragment.annotate(
+            5,
+            9,
+            "A1_exon",
+            "CDS",
+            1,
+            qualifiers=quals,
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w+", delete=False) as f:
+            f.close()
+            IO(self.genome).to_gff(f.name)
+            filehandle = open(f.name, "r")
+            gff = filehandle.read()
+            filehandle.close()
+            os.unlink(f.name)
+
+        # be aware of the tabs in the string below
+        expected = """##gff-version 3
+##sequence-region Bar 1 13
+Bar\tfeature\tgene\t2\t9\t.\t+\t.\tname=A1g
+Bar\tfeature\tCDS\t2\t9\t.\t+\t0\taliases=foo,bar;foo=blah;locus_tag=b0002;name=A1
+Bar\tfeature\tCDS\t2\t6\t.\t+\t0\tName=A1_exon;Parent=A1
+Bar\tfeature\tCDS\t5\t9\t.\t+\t0\tName=A1_exon;Parent=A1
+##FASTA
+>Bar <unknown description>
+%s
+""" % (
+            fragment.sequence,
+        )
+        self.assertEqual(expected, gff)


### PR DESCRIPTION
Added handling in importer and io for subfeature export. Added an additional key to the qualifiers field of the feature these subfeatures belong to and to carry over subfeature qualifier information for export. Resolved some specificity problems with subfeature naming upon import as well.