### PR TITLE
Add --refresh command line argument to Django admin command build_genome_blastdb

### DIFF
--- a/src/edge/management/commands/build_genome_blastdb.py
+++ b/src/edge/management/commands/build_genome_blastdb.py
@@ -3,5 +3,15 @@ from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--refresh',
+            action='store_true',
+            help='Rebuild BLAST database files',
+        )
+
     def handle(self, *args, **options):
-        build_all_genome_dbs()
+        if options['refresh']:
+            build_all_genome_dbs(refresh=True)
+        else:
+            build_all_genome_dbs(refresh=False)


### PR DESCRIPTION
Being able to refresh all genomes without having to use the django shell is useful, currently this argument is available in the `build_all_genome_dbs` function but not exposed to the admin command