### PR TITLE
Improve annotation of integrated DNA and regions around the integration location

### DIFF
--- a/src/edge/recombine.py
+++ b/src/edge/recombine.py
@@ -627,7 +627,7 @@ def trim_cassette_and_region(specified_cassette, annotations, genome, region):
     integrated_sequence = integrated_sequence.lower()
     replaced_sequence = region.sequence.lower()
 
-    # print("region is %s-%s, in fragment of length %s" % (region.start, region.end, fragment_length))
+    # print("region %s-%s, fragment length %s" % (region.start, region.end, fragment_length))
     # print("integrated: %s" % integrated_sequence)
     # print("  original: %s" % replaced_sequence)
 

--- a/src/edge/recombine.py
+++ b/src/edge/recombine.py
@@ -609,14 +609,14 @@ def trim_cassette_and_region(genome, region):
     integrated_sequence = integrated_sequence.lower()
     replaced_sequence = region.sequence.lower()
 
-    print("region %s-%s, fragment length %s" % (region.start, region.end, fragment_length))
-    print("integrated: %s" % integrated_sequence)
-    print("  original: %s" % replaced_sequence)
+    # print("region %s-%s, fragment length %s" % (region.start, region.end, fragment_length))
+    # print("integrated: %s" % integrated_sequence)
+    # print("  original: %s" % replaced_sequence)
 
     trim_front = find_common_start(integrated_sequence, replaced_sequence)
     if trim_front:
         region.cassette = region.cassette[trim_front:]
-        print("trim front", trim_front)
+        # print("trim front", trim_front)
         region.start += trim_front
         region.start = ((region.start - 1) % fragment_length) + 1
 
@@ -626,12 +626,12 @@ def trim_cassette_and_region(genome, region):
     trim_back = find_common_start(integrated_sequence[::-1], replaced_sequence[::-1])
     if trim_back:
         region.cassette = region.cassette[:-trim_back]
-        print("trim back", trim_back)
+        # print("trim back", trim_back)
         region.end -= trim_back
         region.end = ((region.end - 1) % fragment_length) + 1
 
-    print("new coordinates %s-%s" % (region.start, region.end))
-    print("new cassette %s" % region.cassette)
+    # print("new coordinates %s-%s" % (region.start, region.end))
+    # print("new cassette %s" % region.cassette)
     return region
 
 

--- a/src/edge/recombine.py
+++ b/src/edge/recombine.py
@@ -566,7 +566,9 @@ def shift_regions(regions, fragment_id, start, replaced, added, new_fragment_id)
     if len(regions) == 0:
         return []
 
-    assert start <= regions[0].start
+    for r in regions:
+        if r.fragment_id == fragment_id:
+            assert start <= r.start
 
     def updated_region(region):
         if region.start <= start + replaced - 1:  # overlapping

--- a/src/edge/recombine.py
+++ b/src/edge/recombine.py
@@ -763,10 +763,7 @@ def trim_cassette_and_region(specified_cassette, annotations, genome, region):
 
     trim_front = find_common_start(integrated_sequence, replaced_sequence)
     if trim_front:
-        if region.cassette_reversed:
-           region.cassette = region.cassette[:-trim_front]
-        else:
-           region.cassette = region.cassette[trim_front:]
+        region.cassette = region.cassette[trim_front:]
         # print("trim front", trim_front)
         region.start += trim_front
         region.start = ((region.start - 1) % fragment_length) + 1
@@ -776,10 +773,7 @@ def trim_cassette_and_region(specified_cassette, annotations, genome, region):
 
     trim_back = find_common_start(integrated_sequence[::-1], replaced_sequence[::-1])
     if trim_back:
-        if region.cassette_reversed:
-           region.cassette = region.cassette[trim_back:]
-        else:
-           region.cassette = region.cassette[:-trim_back]
+        region.cassette = region.cassette[:-trim_back]
         # print("trim back", trim_back)
         region.end -= trim_back
         region.end = ((region.end - 1) % fragment_length) + 1

--- a/src/edge/tests/test_recombine.py
+++ b/src/edge/tests/test_recombine.py
@@ -448,10 +448,10 @@ class GenomeRecombinationTest(TestCase):
 
         a = c.fragments.all()[0].indexed_fragment().annotations()
         self.assertEquals(len(a), 1)
-        self.assertEquals(a[0].base_first, len(upstream) + 1)
-        self.assertEquals(a[0].base_last, len(upstream + cassette))
+        self.assertEquals(a[0].base_first, len(upstream) + len(front_bs) + 1)
+        self.assertEquals(a[0].base_last, len(upstream + front_bs + replaced))
         self.assertEquals(a[0].feature_base_first, 1)
-        self.assertEquals(a[0].feature_base_last, len(cassette))
+        self.assertEquals(a[0].feature_base_last, len(replaced))
         self.assertEquals(a[0].feature.strand, 1)
         self.assertEquals(a[0].feature.operation.type, Operation.RECOMBINATION[0])
         self.assertEquals(a[0].feature.operation.genome, c)
@@ -476,10 +476,10 @@ class GenomeRecombinationTest(TestCase):
 
         a = c.fragments.all()[0].indexed_fragment().annotations()
         self.assertEquals(len(a), 1)
-        self.assertEquals(a[0].base_first, len(upstream) + 1)
-        self.assertEquals(a[0].base_last, len(upstream + cassette))
+        self.assertEquals(a[0].base_first, len(upstream) + len(front_bs) + 1)
+        self.assertEquals(a[0].base_last, len(upstream + front_bs + replaced))
         self.assertEquals(a[0].feature_base_first, 1)
-        self.assertEquals(a[0].feature_base_last, len(cassette))
+        self.assertEquals(a[0].feature_base_last, len(replaced))
         # on reverse strand
         self.assertEquals(a[0].feature.strand, -1)
         self.assertEquals(a[0].feature.operation.type, Operation.RECOMBINATION[0])
@@ -505,15 +505,15 @@ class GenomeRecombinationTest(TestCase):
         self.assertNotEqual(g.id, c.id)
         self.assertEquals(
             c.fragments.all()[0].indexed_fragment().sequence,
-            "".join([downstream, upstream, cassette]),
+            "".join([back_bs, downstream, upstream, front_bs, replaced])
         )
 
         a = c.fragments.all()[0].indexed_fragment().annotations()
         self.assertEquals(len(a), 1)
-        self.assertEquals(a[0].base_first, len(downstream + upstream) + 1)
+        self.assertEquals(a[0].base_first, len(back_bs + downstream + upstream + front_bs) + 1)
         self.assertEquals(a[0].base_last, len(downstream + upstream + cassette))
         self.assertEquals(a[0].feature_base_first, 1)
-        self.assertEquals(a[0].feature_base_last, len(cassette))
+        self.assertEquals(a[0].feature_base_last, len(replaced))
         self.assertEquals(a[0].feature.strand, 1)
         self.assertEquals(a[0].feature.operation.type, Operation.RECOMBINATION[0])
         self.assertEquals(a[0].feature.operation.genome, c)
@@ -538,7 +538,7 @@ class GenomeRecombinationTest(TestCase):
         self.assertNotEqual(g.id, c.id)
         self.assertEquals(
             c.fragments.all()[0].indexed_fragment().sequence,
-            "".join([downstream, upstream, cassette]),
+            "".join([front_bs[8:], replaced, back_bs, downstream, upstream, front_bs[0:8]]),
         )
 
     def test_recombine_when_back_arm_is_across_circular_boundary(self):
@@ -561,7 +561,7 @@ class GenomeRecombinationTest(TestCase):
         self.assertNotEqual(g.id, c.id)
         self.assertEquals(
             c.fragments.all()[0].indexed_fragment().sequence,
-            "".join([downstream, upstream, cassette]),
+            "".join([back_bs[8:], downstream, upstream, front_bs, replaced, back_bs[0:8]])
         )
 
     def test_recombines_with_reverse_complement_cassette_correctly(self):
@@ -846,14 +846,16 @@ class GenomeRecombinationTest(TestCase):
         c = recombine(g, cassette, arm_len)
         self.assertEquals(
             c.fragments.all()[0].indexed_fragment().sequence,
-            downstream
+            back_bs
+            + downstream
             + "t" * 20
             + upstream
             + cassette
             + downstream
             + "c" * 20
             + upstream
-            + cassette,
+            + front_bs
+            + replaced,
         )
 
     def test_multiple_recombines_return_same_child(self):

--- a/src/edge/tests/test_recombine_annotations.py
+++ b/src/edge/tests/test_recombine_annotations.py
@@ -235,7 +235,7 @@ class GenomeRecombinationAnnotationsTest(TestCase):
         self.assertEquals(a.feature_base_first, 12)
         self.assertEquals(a.feature_base_last, 45)
 
-    def test_preserves_annotations_on_homology_arm_fwd_that_have_not_changed_with_replacement_sequence(self):
+    def test_preserves_annotations_on_homology_arm_fwd_when_inserting_sequence(self):
         cassette = "".join([self.front_bs, "aaa", self.back_bs])
 
         # add annotaiton on upstream arm
@@ -263,7 +263,7 @@ class GenomeRecombinationAnnotationsTest(TestCase):
         a = annotations[1]
         self.assertEquals(a.feature.type, "operation")
 
-    def test_preserves_annotations_on_homology_arm_fwd_that_have_not_changed_when_doing_ko(self):
+    def test_preserves_annotations_on_homology_arm_fwd_when_doing_ko(self):
         cassette = "".join([self.front_bs, self.back_bs])
 
         # add annotaiton on upstream arm
@@ -288,7 +288,7 @@ class GenomeRecombinationAnnotationsTest(TestCase):
         self.assertEquals(a.base_first, len(self.upstream) + 2)
         self.assertEquals(a.base_last, len(self.upstream) + len(self.front_bs))
 
-    def test_preserves_annotations_on_homology_arm_rev_that_have_not_changed(self):
+    def test_preserves_annotations_on_homology_arm_rev(self):
         cassette = "".join([self.front_bs, self.back_bs])
 
         # add annotaiton on reverse strand of downstream arm

--- a/src/edge/tests/test_recombine_annotations.py
+++ b/src/edge/tests/test_recombine_annotations.py
@@ -5,7 +5,7 @@ from Bio.Seq import Seq
 from django.test import TestCase
 
 import edge.orfs
-from edge.recombine import find_swap_region_with_annotations, recombine
+from edge.recombine import recombine
 from edge.models import Genome, Fragment, Genome_Fragment
 from edge.blastdb import build_all_genome_dbs, fragment_fasta_fn
 
@@ -27,7 +27,7 @@ class GenomeRecombinationAnnotationsTest(TestCase):
     def setUp(self):
         self.upstream = "gagattgtccgcgtttt"
         self.front_bs = "catagcgcacaggacgcggag"
-        self.middle = "cggcaccttaattgcgaattgcgagctgacgtctgcatgtagccg"
+        self.middle = "cggcaccttaattgcgaattgcgagctgacgtctgcatgtagccc"
         self.back_bs = "taatgaccccgaagcagg"
         self.downstream = "gttaaggcgcgaacat"
         self.template = "".join(
@@ -43,185 +43,6 @@ class GenomeRecombinationAnnotationsTest(TestCase):
     def tearDown(self):
         edge.orfs.min_protein_len = self.old_min_protein_len
 
-    def test_does_not_preserve_annotation_if_replaced_is_different(self):
-        replaced = "aaaaaaaaaaaaaaaaaaa"
-        cassette = "".join([self.front_bs, replaced, self.back_bs])
-
-        self.fragment.annotate(
-            len(self.upstream) + len(self.front_bs),
-            len(self.upstream) + len(self.front_bs) + len(self.middle) - 1,
-            "Foo",
-            "gene",
-            1,
-        )
-
-        r = find_swap_region_with_annotations(self.genome, cassette, self.arm_len)
-        self.assertEquals(len(r), 1)
-        self.assertEquals(len(r[0].cassette_annotations), 0)
-
-    def test_preserves_annotation_with_single_mutation(self):
-        replaced = [c for c in self.middle]
-        self.assertEquals(replaced[10], "a")
-        replaced[10] = "c"
-        replaced = "".join(replaced)
-        cassette = "".join([self.front_bs, replaced, self.back_bs])
-
-        self.fragment.annotate(
-            len(self.upstream) + len(self.front_bs) + 1,
-            len(self.upstream) + len(self.front_bs) + len(self.middle),
-            "Foo",
-            "gene",
-            1,
-        )
-
-        r = find_swap_region_with_annotations(self.genome, cassette, self.arm_len)
-        self.assertEquals(len(r), 1)
-        self.assertEquals(len(r[0].cassette_annotations), 1)
-        a = r[0].cassette_annotations[0]
-        self.assertEquals(a["base_first"], len(self.front_bs) + 1)
-        self.assertEquals(a["base_last"], len(self.front_bs) + len(self.middle))
-        self.assertEquals(a["feature_name"], "Foo A11C")
-
-    def test_detects_insertion(self):
-        replaced = self.middle[0:10] + "c" + self.middle[10:]
-        self.assertEquals(replaced[10], "c")
-        cassette = "".join([self.front_bs, replaced, self.back_bs])
-
-        self.fragment.annotate(
-            len(self.upstream) + len(self.front_bs) + 1,
-            len(self.upstream) + len(self.front_bs) + len(self.middle),
-            "Foo",
-            "gene",
-            1,
-        )
-
-        r = find_swap_region_with_annotations(self.genome, cassette, self.arm_len)
-        self.assertEquals(len(r), 1)
-        self.assertEquals(len(r[0].cassette_annotations), 1)
-        a = r[0].cassette_annotations[0]
-        self.assertEquals(a["base_first"], len(self.front_bs) + 1)
-        self.assertEquals(a["base_last"], len(self.front_bs) + len(self.middle) + 1)
-        self.assertEquals(a["feature_name"], "Foo +11C")
-
-    def test_detects_deletion(self):
-        replaced = self.middle[0:13] + self.middle[14:]
-        cassette = "".join([self.front_bs, replaced, self.back_bs])
-
-        self.fragment.annotate(
-            len(self.upstream) + len(self.front_bs) + 1,
-            len(self.upstream) + len(self.front_bs) + len(self.middle),
-            "Foo",
-            "gene",
-            1,
-        )
-
-        r = find_swap_region_with_annotations(self.genome, cassette, self.arm_len)
-        self.assertEquals(len(r), 1)
-        self.assertEquals(len(r[0].cassette_annotations), 1)
-        a = r[0].cassette_annotations[0]
-        self.assertEquals(a["base_first"], len(self.front_bs) + 1)
-        self.assertEquals(a["base_last"], len(self.front_bs) + len(self.middle) - 1)
-        self.assertEquals(a["feature_name"], "Foo -14G")
-
-    def test_preserves_unchanged_annotation(self):
-        replaced = self.middle[0:10] + self.middle[11:]
-        cassette = "".join([self.front_bs, replaced, self.back_bs])
-
-        self.fragment.annotate(
-            len(self.upstream) + len(self.front_bs) + 12,
-            len(self.upstream) + len(self.front_bs) + len(self.middle) - 1,
-            "Foo",
-            "gene",
-            1,
-        )
-
-        r = find_swap_region_with_annotations(self.genome, cassette, self.arm_len)
-        self.assertEquals(len(r), 1)
-        self.assertEquals(len(r[0].cassette_annotations), 1)
-        a = r[0].cassette_annotations[0]
-        self.assertEquals(a["base_first"], len(self.front_bs) + 12 - 1)
-        self.assertEquals(a["base_last"], len(self.front_bs) + len(self.middle) - 1 - 1)
-        self.assertEquals(a["feature_name"], "Foo")
-
-    def test_preserves_feature_direction_and_type(self):
-        replaced = self.middle[0:13] + self.middle[14:]
-        cassette = "".join([self.front_bs, replaced, self.back_bs])
-
-        self.fragment.annotate(
-            len(self.upstream) + len(self.front_bs) + 1,
-            len(self.upstream) + len(self.front_bs) + len(self.middle),
-            "Foo",
-            "foobar",
-            -1,
-        )
-
-        r = find_swap_region_with_annotations(self.genome, cassette, self.arm_len)
-        self.assertEquals(len(r), 1)
-        self.assertEquals(len(r[0].cassette_annotations), 1)
-        a = r[0].cassette_annotations[0]
-        self.assertEquals(a["base_first"], len(self.front_bs) + 1)
-        self.assertEquals(a["base_last"], len(self.front_bs) + len(self.middle) - 1)
-        self.assertEquals(a["feature_name"], "Foo -14G")
-        self.assertEquals(a["feature_type"], "foobar")
-        self.assertEquals(a["feature_strand"], -1)
-
-    def test_preserves_multiple_annotations(self):
-        replaced = self.middle[0:13] + self.middle[14:]
-        cassette = "".join([self.front_bs, replaced, self.back_bs])
-
-        self.fragment.annotate(
-            len(self.upstream) + 2, len(self.upstream) + 10, "Bar", "static", -1
-        )
-        self.fragment.annotate(
-            len(self.upstream) + len(self.front_bs) + 1,
-            len(self.upstream) + len(self.front_bs) + len(self.middle),
-            "Foo",
-            "changed",
-            1,
-        )
-
-        r = find_swap_region_with_annotations(self.genome, cassette, self.arm_len)
-        self.assertEquals(len(r), 1)
-        self.assertEquals(len(r[0].cassette_annotations), 2)
-
-        a = r[0].cassette_annotations[0]
-        self.assertEquals(a["base_first"], 2)
-        self.assertEquals(a["base_last"], 10)
-        self.assertEquals(a["feature_name"], "Bar")
-        self.assertEquals(a["feature_type"], "static")
-        self.assertEquals(a["feature_strand"], -1)
-
-        a = r[0].cassette_annotations[1]
-        self.assertEquals(a["base_first"], len(self.front_bs) + 1)
-        self.assertEquals(a["base_last"], len(self.front_bs) + len(self.middle) - 1)
-        self.assertEquals(a["feature_name"], "Foo -14G")
-        self.assertEquals(a["feature_type"], "changed")
-        self.assertEquals(a["feature_strand"], 1)
-
-    def test_computes_annotation_for_reverse_cassette(self):
-        replaced = [c for c in self.middle]
-        self.assertEquals(replaced[10], "a")
-        replaced[10] = "c"
-        replaced = "".join(replaced)
-        cassette = "".join([self.front_bs, replaced, self.back_bs])
-        cassette = str(Seq(cassette).reverse_complement())
-
-        self.fragment.annotate(
-            len(self.upstream) + len(self.front_bs) + 1,
-            len(self.upstream) + len(self.front_bs) + len(self.middle),
-            "Foo",
-            "gene",
-            1,
-        )
-
-        r = find_swap_region_with_annotations(self.genome, cassette, self.arm_len)
-        self.assertEquals(len(r), 1)
-        self.assertEquals(len(r[0].cassette_annotations), 1)
-        a = r[0].cassette_annotations[0]
-        self.assertEquals(a["base_first"], len(self.front_bs) + 1)
-        self.assertEquals(a["base_last"], len(self.front_bs) + len(self.middle))
-        self.assertEquals(a["feature_name"], "Foo A11C")
-
     def test_returns_new_orf(self):
         replaced = "atgatcatcatcatcatcatcatcatcatcatcatcatcatcatcatctag"
         cassette = "".join([self.front_bs, replaced, self.back_bs])
@@ -234,19 +55,24 @@ class GenomeRecombinationAnnotationsTest(TestCase):
             1,
         )
 
-        r = find_swap_region_with_annotations(self.genome, cassette, self.arm_len)
-        self.assertEquals(len(r), 1)
-        self.assertEquals(len(r[0].cassette_annotations), 1)
+        c = recombine(self.genome, cassette, self.arm_len)
+        f = c.fragments.all()[0].indexed_fragment()
 
-        a = r[0].cassette_annotations[0]
-        self.assertEquals(a["base_first"], len(self.front_bs) + 1)
-        self.assertEquals(a["base_last"], len(self.front_bs) + len(replaced))
-        self.assertEquals(a["feature_name"], "ORF frame 1")
-        self.assertEquals(a["feature_type"], "ORF")
-        self.assertEquals(a["feature_strand"], 1)
+        annotations = f.annotations()
+        self.assertEquals(len(annotations), 2)
 
-    def test_finds_orf_in_reverse_direction(self):
-        replaced = "atgatcatcatcatcatcatcatcatcatcatcatcatcatcatcatctag"
+        a = annotations[0]
+        self.assertEquals(a.feature.type, "operation")
+
+        a = annotations[1]
+        self.assertEquals(a.base_first, len(self.upstream + self.front_bs) + 1)
+        self.assertEquals(a.base_last, len(self.upstream + self.front_bs + replaced))
+        self.assertEquals(a.feature.name, "ORF frame 1")
+        self.assertEquals(a.feature.type, "ORF")
+        self.assertEquals(a.feature.strand, 1)
+
+    def test_returns_new_orf_in_reverse(self):
+        replaced = "atgatcatcatcatcatcatcatcatcatcatcatcatcatcatcatctaa"
         replaced = str(Seq(replaced).reverse_complement())
         cassette = "".join([self.front_bs, replaced, self.back_bs])
 
@@ -258,18 +84,23 @@ class GenomeRecombinationAnnotationsTest(TestCase):
             1,
         )
 
-        r = find_swap_region_with_annotations(self.genome, cassette, self.arm_len)
-        self.assertEquals(len(r), 1)
-        self.assertEquals(len(r[0].cassette_annotations), 1)
+        c = recombine(self.genome, cassette, self.arm_len)
+        f = c.fragments.all()[0].indexed_fragment()
 
-        a = r[0].cassette_annotations[0]
-        self.assertEquals(a["base_first"], len(self.front_bs) + 1)
-        self.assertEquals(a["base_last"], len(self.front_bs) + len(replaced))
-        self.assertEquals(a["feature_name"], "ORF frame 1")
-        self.assertEquals(a["feature_type"], "ORF")
-        self.assertEquals(a["feature_strand"], -1)
+        annotations = f.annotations()
+        self.assertEquals(len(annotations), 2)
 
-    def test_adds_multiple_annotations_to_modified_genome(self):
+        a = annotations[0]
+        self.assertEquals(a.feature.type, "operation")
+
+        a = annotations[1]
+        self.assertEquals(a.base_first, len(self.upstream + self.front_bs) + 1)
+        self.assertEquals(a.base_last, len(self.upstream + self.front_bs + replaced))
+        self.assertEquals(a.feature.name, "ORF frame 1")
+        self.assertEquals(a.feature.type, "ORF")
+        self.assertEquals(a.feature.strand, -1)
+
+    def test_annotates_correctly_when_one_bp_is_removed(self):
         replaced = self.middle[0:13] + self.middle[14:]
         cassette = "".join([self.front_bs, replaced, self.back_bs])
 
@@ -291,25 +122,75 @@ class GenomeRecombinationAnnotationsTest(TestCase):
         self.assertEquals(len(annotations), 3)
 
         a = annotations[0]
-        self.assertEquals(a.feature.type, "operation")
-
-        a = annotations[1]
         self.assertEquals(a.feature.name, "Bar")
         self.assertEquals(a.feature.type, "static")
         self.assertEquals(a.feature.strand, -1)
         self.assertEquals(a.base_first, len(self.upstream) + 2)
         self.assertEquals(a.base_last, len(self.upstream) + 10)
 
-        a = annotations[2]
-        self.assertEquals(a.feature.name, "Foo -14G")
+        a = annotations[1]
+        self.assertEquals(a.feature.name, "Foo")
         self.assertEquals(a.feature.type, "changed")
         self.assertEquals(a.feature.strand, 1)
-        self.assertEquals(a.base_first, len(self.upstream) + len(self.front_bs) + 1)
-        self.assertEquals(
-            a.base_last, len(self.upstream) + len(self.front_bs) + len(self.middle) - 1
+        self.assertEquals(a.base_first, len(self.upstream + self.front_bs) + 1)
+        self.assertEquals(a.base_last, len(self.upstream + self.front_bs) + 13)
+        self.assertEquals(a.feature_base_first, 1)
+        self.assertEquals(a.feature_base_last, 13)
+
+        a = annotations[2]
+        self.assertEquals(a.feature.name, "Foo")
+        self.assertEquals(a.feature.type, "changed")
+        self.assertEquals(a.feature.strand, 1)
+        self.assertEquals(a.base_first, len(self.upstream + self.front_bs) + 14)
+        self.assertEquals(a.base_last, len(self.upstream + self.front_bs) + 44)
+        self.assertEquals(a.feature_base_first, 15)
+        self.assertEquals(a.feature_base_last, 45)
+
+    def test_adds_single_snp_change_splits_original_annotation(self):
+        replaced = [c for c in self.middle]
+        self.assertEquals(replaced[10], "a")
+        replaced[10] = "c"
+        replaced = "".join(replaced)
+        cassette = "".join([self.front_bs, replaced, self.back_bs])
+
+        self.fragment.annotate(
+            len(self.upstream) + len(self.front_bs) + 1,
+            len(self.upstream) + len(self.front_bs) + len(self.middle),
+            "Foo",
+            "gene",
+            1,
         )
 
-    def test_adds_annotations_correctly_with_reverse_cassette(self):
+        c = recombine(self.genome, cassette, self.arm_len)
+        f = c.fragments.all()[0].indexed_fragment()
+
+        annotations = f.annotations()
+        self.assertEquals(len(annotations), 3)
+        for a in annotations:
+            print(str(a))
+
+        a = annotations[0]
+        self.assertEquals(a.feature.name, "Foo")
+        self.assertEquals(a.feature.type, "gene")
+        self.assertEquals(a.feature.strand, 1)
+        self.assertEquals(a.base_first, len(self.upstream) + len(self.front_bs) + 1)
+        self.assertEquals(a.base_last, len(self.upstream) + len(self.front_bs) + 10)
+        self.assertEquals(a.feature_base_first, 1)
+        self.assertEquals(a.feature_base_last, 10)
+
+        a = annotations[1]
+        self.assertEquals(a.feature.type, "operation")
+
+        a = annotations[2]
+        self.assertEquals(a.feature.name, "Foo")
+        self.assertEquals(a.feature.type, "gene")
+        self.assertEquals(a.feature.strand, 1)
+        self.assertEquals(a.base_first, len(self.upstream) + len(self.front_bs) + 12)
+        self.assertEquals(a.base_last, len(self.upstream) + len(self.front_bs) + 45)
+        self.assertEquals(a.feature_base_first, 12)
+        self.assertEquals(a.feature_base_last, 45)
+
+    def test_adds_single_snp_change_splits_original_annotation_when_cassette_is_reversed(self):
         replaced = [c for c in self.middle]
         self.assertEquals(replaced[10], "a")
         replaced[10] = "c"
@@ -329,22 +210,33 @@ class GenomeRecombinationAnnotationsTest(TestCase):
         f = c.fragments.all()[0].indexed_fragment()
 
         annotations = f.annotations()
-        self.assertEquals(len(annotations), 2)
+        self.assertEquals(len(annotations), 3)
+        for a in annotations:
+            print(str(a))
 
         a = annotations[0]
-        self.assertEquals(a.feature.type, "operation")
-
-        a = annotations[1]
-        self.assertEquals(a.feature.name, "Foo A11C")
+        self.assertEquals(a.feature.name, "Foo")
         self.assertEquals(a.feature.type, "gene")
         self.assertEquals(a.feature.strand, 1)
         self.assertEquals(a.base_first, len(self.upstream) + len(self.front_bs) + 1)
-        self.assertEquals(
-            a.base_last, len(self.upstream) + len(self.front_bs) + len(self.middle)
-        )
+        self.assertEquals(a.base_last, len(self.upstream) + len(self.front_bs) + 10)
+        self.assertEquals(a.feature_base_first, 1)
+        self.assertEquals(a.feature_base_last, 10)
 
-    def test_preserves_annotations_on_homology_arm_fwd_that_have_not_changed(self):
-        cassette = "".join([self.front_bs, self.back_bs])
+        a = annotations[1]
+        self.assertEquals(a.feature.type, "operation")
+
+        a = annotations[2]
+        self.assertEquals(a.feature.name, "Foo")
+        self.assertEquals(a.feature.type, "gene")
+        self.assertEquals(a.feature.strand, 1)
+        self.assertEquals(a.base_first, len(self.upstream) + len(self.front_bs) + 12)
+        self.assertEquals(a.base_last, len(self.upstream) + len(self.front_bs) + 45)
+        self.assertEquals(a.feature_base_first, 12)
+        self.assertEquals(a.feature_base_last, 45)
+
+    def test_preserves_annotations_on_homology_arm_fwd_that_have_not_changed_with_replacement_sequence(self):
+        cassette = "".join([self.front_bs, "aaa", self.back_bs])
 
         # add annotaiton on upstream arm
         self.fragment.annotate(
@@ -362,9 +254,34 @@ class GenomeRecombinationAnnotationsTest(TestCase):
         self.assertEquals(len(annotations), 2)
 
         a = annotations[0]
-        self.assertEquals(a.feature.type, "operation")
+        self.assertEquals(a.feature.name, "Up arm")
+        self.assertEquals(a.feature.type, "feature")
+        self.assertEquals(a.feature.strand, 1)
+        self.assertEquals(a.base_first, len(self.upstream) + 2)
+        self.assertEquals(a.base_last, len(self.upstream) + len(self.front_bs))
 
         a = annotations[1]
+        self.assertEquals(a.feature.type, "operation")
+
+    def test_preserves_annotations_on_homology_arm_fwd_that_have_not_changed_when_doing_ko(self):
+        cassette = "".join([self.front_bs, self.back_bs])
+
+        # add annotaiton on upstream arm
+        self.fragment.annotate(
+            len(self.upstream) + 2,
+            len(self.upstream) + len(self.front_bs),
+            "Up arm",
+            "feature",
+            1,
+        )
+
+        c = recombine(self.genome, cassette, self.arm_len)
+        f = c.fragments.all()[0].indexed_fragment()
+
+        annotations = f.annotations()
+        self.assertEquals(len(annotations), 1)
+
+        a = annotations[0]
         self.assertEquals(a.feature.name, "Up arm")
         self.assertEquals(a.feature.type, "feature")
         self.assertEquals(a.feature.strand, 1)
@@ -390,12 +307,9 @@ class GenomeRecombinationAnnotationsTest(TestCase):
         f = c.fragments.all()[0].indexed_fragment()
 
         annotations = f.annotations()
-        self.assertEquals(len(annotations), 2)
+        self.assertEquals(len(annotations), 1)
 
         a = annotations[0]
-        self.assertEquals(a.feature.type, "operation")
-
-        a = annotations[1]
         self.assertEquals(a.feature.name, "Down arm")
         self.assertEquals(a.feature.type, "feature")
         self.assertEquals(a.feature.strand, -1)


### PR DESCRIPTION
Previously, when we integrate DNA with homology arms, we remove the annotations occupied by the homology arms. This change preserves those annotations on homology arms.