### PR TITLE
Improved BLAST performance with multithreading and JSON output type

### DIFF
--- a/src/edge/blast.py
+++ b/src/edge/blast.py
@@ -1,13 +1,14 @@
+import json
 import os
-import tempfile
 import subprocess
-from functools import lru_cache
-from django.conf import settings
-from edge.models import Fragment
+import tempfile
 from Bio.Blast.Applications import NcbiblastnCommandline
 from Bio.Blast.Applications import NcbitblastnCommandline
-from Bio.Blast import NCBIXML
+from functools import lru_cache
 
+from django.conf import settings
+
+from edge.models import Fragment
 
 BLAST_DB = "%s/edge-nucl" % settings.NCBI_DATA_DIR
 
@@ -84,14 +85,14 @@ def blast(dbname, blast_program, query):
         infile = f.name
         f.write(">Query\n%s\n" % query)
 
-    outfile = "%s.out.xml" % infile
+    outfile = "%s.out.json" % infile
     if blast_program == "tblastn":
         blast_cl = NcbitblastnCommandline(
-            query=infile, db=dbname, word_size=6, outfmt=5, out=outfile
+            query=infile, db=dbname, word_size=6, outfmt=15, out=outfile, num_threads=4
         )
     else:
         blast_cl = NcbiblastnCommandline(
-            query=infile, db=dbname, word_size=6, outfmt=5, out=outfile
+            query=infile, db=dbname, word_size=6, outfmt=15, out=outfile, num_threads=4
         )
 
     cl = str(blast_cl)
@@ -105,41 +106,43 @@ def blast(dbname, blast_program, query):
 
     results = []
     with open(outfile, "r") as f:
-        blast_record = NCBIXML.read(f)
-        for alignment in blast_record.alignments:
-            accession = Blast_Accession(alignment.accession)
-            for hsp in alignment.hsps:
-                if accession.fragment_length is not None:
-                    if (
-                        hsp.sbjct_start > accession.fragment_length
-                        and hsp.sbjct_end > accession.fragment_length
-                    ):
-                        continue
-                    # don't apply '% accession.fragment_length' to
-                    # sbjct_start/end. Blast_Result#strand compares sbjct_start
-                    # and sbjct_end to determine which strand the hit is on.
-                    # Caller should just handle when sbjct_start/end is greater
-                    # than fragment length. alternatively, we can store strand
-                    # explicit, but that also creates complexity when using
-                    # sbjct_start/end coordinates.
+        data = json.load(f)
+        for output in data['BlastOutput2']:
+            for hit in output['report']['results']['search']['hits']:
+                desc = hit['description'][0]
+                accession = Blast_Accession(desc['accession'])
+                for hsp in hit['hsps']:
+                    if accession.fragment_length is not None:
+                        if (
+                            hsp['hit_from'] > accession.fragment_length
+                            and hsp['hit_to'] > accession.fragment_length
+                        ):
+                            continue
+                        # don't apply '% accession.fragment_length' to
+                        # sbjct_start/end. Blast_Result#strand compares sbjct_start
+                        # and sbjct_end to determine which strand the hit is on.
+                        # Caller should just handle when sbjct_start/end is greater
+                        # than fragment length. alternatively, we can store strand
+                        # explicit, but that also creates complexity when using
+                        # sbjct_start/end coordinates.
 
-                f = Blast_Result(
-                    fragment_id=accession.fragment_id,
-                    fragment_length=accession.fragment_length,
-                    hit_def=alignment.hit_def,
-                    query_start=hsp.query_start,
-                    query_end=hsp.query_end,
-                    subject_start=hsp.sbjct_start,
-                    subject_end=hsp.sbjct_end,
-                    evalue=hsp.expect,
-                    alignment=dict(
-                        query=hsp.query,
-                        match=hsp.match,
-                        matchi=inverse_match(hsp.match),
-                        subject=hsp.sbjct,
-                    ),
-                )
-                results.append(f)
+                    f = Blast_Result(
+                        fragment_id=accession.fragment_id,
+                        fragment_length=accession.fragment_length,
+                        hit_def=desc['title'],
+                        query_start=hsp['query_from'],
+                        query_end=hsp['query_to'],
+                        subject_start=hsp['hit_from'],
+                        subject_end=hsp['hit_to'],
+                        evalue=hsp['evalue'],
+                        alignment=dict(
+                            query=hsp['qseq'],
+                            match=hsp['midline'],
+                            matchi=inverse_match(hsp['midline']),
+                            subject=hsp['hseq'],
+                        ),
+                    )
+                    results.append(f)
 
     os.unlink(outfile)
     return results


### PR DESCRIPTION
Performance changes on 2kb query:

(Before)
infile generation: 0.003701925277709961 seconds
blast command generation: 0.0006384849548339844 seconds
**blast cl call: 375.5496497154236 seconds**
opening outfile: 0.0005927085876464844 seconds
**reading outfile into NCBIXML: 74.45608043670654 seconds**
result reading: 7.70909857749939 seconds
**_Single-threaded XML time: 458.09611415863037 seconds_**

(After)
infile generation: 0.0029015541076660156 seconds
blast command generation: 0.0012469291687011719 seconds
**blast cl call: 131.6555197238922 seconds**
opening outfile: 0.0009796619415283203 seconds
**reading outfile into json: 2.003464698791504 seconds**
result reading: 5.763728380203247 seconds
**_4-threaded JSON time: 139.61657047271729 seconds_**