### PR TITLE
return template annotations from pcr

### DIFF
--- a/src/edge/pcr.py
+++ b/src/edge/pcr.py
@@ -176,8 +176,8 @@ def pcr_from_genome(genome, primer_a_sequence, primer_b_sequence):
                 region=region,
                 fragment_name=fragment.name,
                 fragment_id=fragment.id,
-                template_sequence=fragment.get_sequence(bp_lo=bp_lo, bp_hi=bp_hi),
-                template_annotations=fragment.annotations(bp_lo=bp_lo, bp_hi=bp_hi),
+                sequence=fragment.get_sequence(bp_lo=bp_lo, bp_hi=bp_hi),
+                annotations=fragment.annotations(bp_lo=bp_lo, bp_hi=bp_hi),
             ),
         )
     else:

--- a/src/edge/pcr.py
+++ b/src/edge/pcr.py
@@ -164,10 +164,9 @@ def pcr_from_genome(genome, primer_a_sequence, primer_b_sequence):
                     uniq_products[k] = product
 
     if len(pcr_products) == 1:
-        product = pcr_products[0][0]
-        region = pcr_products[0][1]
-        region = region["region"]
-        fragment = region["fragment"]  # already an indexed fragment
+        product, template_info = pcr_products[0]
+        region = template_info["region"]
+        fragment = template_info["fragment"]  # already an indexed fragment
         return (
             product,
             primer_a_results,

--- a/src/edge/pcr.py
+++ b/src/edge/pcr.py
@@ -167,6 +167,7 @@ def pcr_from_genome(genome, primer_a_sequence, primer_b_sequence):
         product, template_info = pcr_products[0]
         region = template_info["region"]
         fragment = template_info["fragment"]  # already an indexed fragment
+        bp_lo, bp_hi = region
         return (
             product,
             primer_a_results,
@@ -175,7 +176,8 @@ def pcr_from_genome(genome, primer_a_sequence, primer_b_sequence):
                 region=region,
                 fragment_name=fragment.name,
                 fragment_id=fragment.id,
-                annotations=fragment.annotations(bp_lo=region[0], bp_hi=region[1])
+                template_sequence=fragment.get_sequence(bp_lo=bp_lo, bp_hi=bp_hi),
+                template_annotations=fragment.annotations(bp_lo=bp_lo, bp_hi=bp_hi),
             ),
         )
     else:

--- a/src/edge/pcr.py
+++ b/src/edge/pcr.py
@@ -166,14 +166,17 @@ def pcr_from_genome(genome, primer_a_sequence, primer_b_sequence):
     if len(pcr_products) == 1:
         product = pcr_products[0][0]
         region = pcr_products[0][1]
+        region = region["region"]
+        fragment = region["fragment"]  # already an indexed fragment
         return (
             product,
             primer_a_results,
             primer_b_results,
             dict(
-                region=region["region"],
-                fragment_name=region["fragment"].name,
-                fragment_id=region["fragment"].id,
+                region=region,
+                fragment_name=fragment.name,
+                fragment_id=fragment.id,
+                annotations=fragment.annotations(bp_lo=region[0], bp_hi=region[1])
             ),
         )
     else:

--- a/src/edge/views.py
+++ b/src/edge/views.py
@@ -591,10 +591,10 @@ class GenomePcrView(ViewBase):
             product, primer_a_results, primer_b_results, template_info
         ) = pcr_from_genome(genome, primers[0], primers[1])
         # Convert annotations in template_info to dictionary.
-        if template_info and "annotations" in template_info:
-            template_info["annotations"] = [
+        if template_info and "template_annotations" in template_info:
+            template_info["template_annotations"] = [
                 FragmentAnnotationsView.to_dict(annotation)
-                for annotation in template_info["annotations"]
+                for annotation in template_info["template_annotations"]
             ]
         r = (
             product,

--- a/src/edge/views.py
+++ b/src/edge/views.py
@@ -591,10 +591,10 @@ class GenomePcrView(ViewBase):
             product, primer_a_results, primer_b_results, template_info
         ) = pcr_from_genome(genome, primers[0], primers[1])
         # Convert annotations in template_info to dictionary.
-        if template_info and "template_annotations" in template_info:
-            template_info["template_annotations"] = [
+        if template_info and "annotations" in template_info:
+            template_info["annotations"] = [
                 FragmentAnnotationsView.to_dict(annotation)
-                for annotation in template_info["template_annotations"]
+                for annotation in template_info["annotations"]
             ]
         r = (
             product,

--- a/src/edge/views.py
+++ b/src/edge/views.py
@@ -583,11 +583,25 @@ class GenomePcrView(ViewBase):
 
         args = parser.parse_args(request)
         primers = args["primers"]
+
         if len(primers) != 2:
             raise Exception("Expecting two primers, got %s" % (primers,))
 
-        r = pcr_from_genome(genome, primers[0], primers[1])
-        r = (r[0], [b.to_dict() for b in r[1]], [b.to_dict() for b in r[2]], r[3])
+        (
+            product, primer_a_results, primer_b_results, template_info
+        ) = pcr_from_genome(genome, primers[0], primers[1])
+        # Convert annotations in template_info to dictionary.
+        if template_info and "annotations" in template_info:
+            template_info["annotations"] = [
+                FragmentAnnotationsView.to_dict(annotation)
+                for annotation in template_info["annotations"]
+            ]
+        r = (
+            product,
+            [b.to_dict() for b in primer_a_results],
+            [b.to_dict() for b in primer_b_results],
+            template_info,
+        )
         return r, 200
 
 


### PR DESCRIPTION
Updated `GenomePcrView` endpoint to return template annotations in the same format as the `FragmentAnnotationsView` endpoint.